### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/166/613/421166613.geojson
+++ b/data/421/166/613/421166613.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008696,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44e42699a6e470dea26ff8246876d8f5",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421166613,
-    "wof:lastmodified":1566630048,
+    "wof:lastmodified":1582318821,
     "wof:name":"Thedtsho",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/169/587/421169587.geojson
+++ b/data/421/169/587/421169587.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008816,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d603d79dda6b075fefa6755d88b8a5b",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421169587,
-    "wof:lastmodified":1566630049,
+    "wof:lastmodified":1582318821,
     "wof:name":"Katsho",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/421/170/333/421170333.geojson
+++ b/data/421/170/333/421170333.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008849,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb768514445fe07e1d9c6ab66e06ce8a",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":421170333,
-    "wof:lastmodified":1566630051,
+    "wof:lastmodified":1582318821,
     "wof:name":"Naja",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/421/171/015/421171015.geojson
+++ b/data/421/171/015/421171015.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008878,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4672be25671e18c3d4e50a9813048f66",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421171015,
-    "wof:lastmodified":1566630053,
+    "wof:lastmodified":1582318822,
     "wof:name":"Nubi",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/421/171/403/421171403.geojson
+++ b/data/421/171/403/421171403.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008892,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67c2cfdd4c33b912154b53e2418c198e",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421171403,
-    "wof:lastmodified":1566630053,
+    "wof:lastmodified":1582318822,
     "wof:name":"Gangte",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/172/353/421172353.geojson
+++ b/data/421/172/353/421172353.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459008932,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0afea1937b7a04ee4b2584bb40ccb04",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421172353,
-    "wof:lastmodified":1566630050,
+    "wof:lastmodified":1582318821,
     "wof:name":"Lamgong",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/421/174/679/421174679.geojson
+++ b/data/421/174/679/421174679.geojson
@@ -264,6 +264,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009040,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2525c03b18e6205eeaed83a901894563",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":421174679,
-    "wof:lastmodified":1566630050,
+    "wof:lastmodified":1582318821,
     "wof:name":"Punakha",
     "wof:parent_id":1108747369,
     "wof:placetype":"locality",

--- a/data/421/177/849/421177849.geojson
+++ b/data/421/177/849/421177849.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009162,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e7bcfb43740e8ec4cc9796f82f86cb5",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421177849,
-    "wof:lastmodified":1566630052,
+    "wof:lastmodified":1582318821,
     "wof:name":"Gangzur",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/421/183/063/421183063.geojson
+++ b/data/421/183/063/421183063.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009357,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16b25aa4da1b76f4a9bfb3f5a996db9b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183063,
-    "wof:lastmodified":1566630052,
+    "wof:lastmodified":1582318822,
     "wof:name":"Dangchhu",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/183/963/421183963.geojson
+++ b/data/421/183/963/421183963.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5936ae912f795258a637435b32ecf808",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183963,
-    "wof:lastmodified":1566630052,
+    "wof:lastmodified":1582318822,
     "wof:name":"Samkhar",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/421/183/965/421183965.geojson
+++ b/data/421/183/965/421183965.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"981894bce045f3b9af48425bda7da58b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183965,
-    "wof:lastmodified":1566630052,
+    "wof:lastmodified":1582318822,
     "wof:name":"Tangsibji",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/421/183/967/421183967.geojson
+++ b/data/421/183/967/421183967.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f57a331709f769aec4ddb986cb5b461f",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421183967,
-    "wof:lastmodified":1566630052,
+    "wof:lastmodified":1582318822,
     "wof:name":"Sephu",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/184/419/421184419.geojson
+++ b/data/421/184/419/421184419.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009410,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ea4d7a49bb991408dd35a2710eaff91",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421184419,
-    "wof:lastmodified":1566630051,
+    "wof:lastmodified":1582318821,
     "wof:name":"Saleng",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/421/190/233/421190233.geojson
+++ b/data/421/190/233/421190233.geojson
@@ -495,6 +495,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459009651,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f91fdab18a37f9e388b357a8a864daf8",
     "wof:hierarchy":[
         {
@@ -506,7 +509,7 @@
         }
     ],
     "wof:id":421190233,
-    "wof:lastmodified":1566630051,
+    "wof:lastmodified":1582318821,
     "wof:name":"Thimphu",
     "wof:parent_id":1108747289,
     "wof:placetype":"locality",

--- a/data/421/204/105/421204105.geojson
+++ b/data/421/204/105/421204105.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3715636d7fac1d3530798a1f226b8e18",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421204105,
-    "wof:lastmodified":1566630049,
+    "wof:lastmodified":1582318821,
     "wof:name":"Chhoekhor",
     "wof:parent_id":85669537,
     "wof:placetype":"county",

--- a/data/421/204/395/421204395.geojson
+++ b/data/421/204/395/421204395.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459010185,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac4b634c6a02f9115a9d28db62317b6c",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421204395,
-    "wof:lastmodified":1566630049,
+    "wof:lastmodified":1582318821,
     "wof:name":"Toewang",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/421/204/397/421204397.geojson
+++ b/data/421/204/397/421204397.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459010185,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cd3bb5dfe3a692c358c556d699edb26",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421204397,
-    "wof:lastmodified":1566630049,
+    "wof:lastmodified":1582318821,
     "wof:name":"Chhubu",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/421/205/147/421205147.geojson
+++ b/data/421/205/147/421205147.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"BT",
     "wof:created":1459010214,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19deecc71e5403d3ae5789add1531fa6",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421205147,
-    "wof:lastmodified":1566630050,
+    "wof:lastmodified":1582318821,
     "wof:name":"Kawang",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/856/321/71/85632171.geojson
+++ b/data/856/321/71/85632171.geojson
@@ -1056,6 +1056,11 @@
     },
     "wof:country":"BT",
     "wof:country_alpha3":"BTN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"452f9b15a5e82e278eec18eeca65e44f",
     "wof:hierarchy":[
         {
@@ -1070,7 +1075,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629976,
+    "wof:lastmodified":1582318817,
     "wof:name":"Bhutan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/695/01/85669501.geojson
+++ b/data/856/695/01/85669501.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Chukha District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f53fdce389e17a019f80a5bf612b44cd",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629972,
+    "wof:lastmodified":1582318816,
     "wof:name":"Chhukha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/05/85669505.geojson
+++ b/data/856/695/05/85669505.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Dagana District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c9b38895445b94cb8eb3bebf170bf73",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629969,
+    "wof:lastmodified":1582318815,
     "wof:name":"Daga",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/09/85669509.geojson
+++ b/data/856/695/09/85669509.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Haa District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e883629655c8b3cbed902fccd161dbcd",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629971,
+    "wof:lastmodified":1582318815,
     "wof:name":"Ha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/13/85669513.geojson
+++ b/data/856/695/13/85669513.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Paro District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1ea787d6a5d29de0944cc04afff2e43",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629975,
+    "wof:lastmodified":1582318817,
     "wof:name":"Paro",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/21/85669521.geojson
+++ b/data/856/695/21/85669521.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Gasa District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41979614543089bef580f5e3a064d2fb",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629970,
+    "wof:lastmodified":1582318815,
     "wof:name":"Gasa",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/23/85669523.geojson
+++ b/data/856/695/23/85669523.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Samtse District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"803c41e1bf237a586e412c875f262aa1",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629974,
+    "wof:lastmodified":1582318817,
     "wof:name":"Samchi",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/27/85669527.geojson
+++ b/data/856/695/27/85669527.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Thimphu District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bcccacc90cdc7a11810f2e3f61f018e",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629970,
+    "wof:lastmodified":1582318815,
     "wof:name":"Thimphu",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/31/85669531.geojson
+++ b/data/856/695/31/85669531.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Punakha District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b00980ba8858fb44f4042fd7df52805c",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629971,
+    "wof:lastmodified":1582318815,
     "wof:name":"Punakha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/37/85669537.geojson
+++ b/data/856/695/37/85669537.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Bumthang District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c09239ebd116edc487bbb7398acc18d",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629972,
+    "wof:lastmodified":1582318816,
     "wof:name":"Bumthang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/41/85669541.geojson
+++ b/data/856/695/41/85669541.geojson
@@ -226,6 +226,9 @@
         "wk:page":"Tsirang District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e71a089886a1c4e39b26f348ecd6f54f",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629973,
+    "wof:lastmodified":1582318816,
     "wof:name":"Chirang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/45/85669545.geojson
+++ b/data/856/695/45/85669545.geojson
@@ -230,6 +230,9 @@
         "wk:page":"Sarpang District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f62610410ee2ab1445a4557b860e2c0d",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629970,
+    "wof:lastmodified":1582318815,
     "wof:name":"Geylegphug",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/49/85669549.geojson
+++ b/data/856/695/49/85669549.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Lhuntse District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b43463d7263862a2dc2ab644378a6fd",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629975,
+    "wof:lastmodified":1582318817,
     "wof:name":"Lhuntshi",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/55/85669555.geojson
+++ b/data/856/695/55/85669555.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q2566021"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8fffc62ba41bfe035fbbcdfaa0c00d4",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629973,
+    "wof:lastmodified":1582318816,
     "wof:name":"Tashi Yangtse",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/59/85669559.geojson
+++ b/data/856/695/59/85669559.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Zhemgang District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"655e43033a04a76864740614b4edebbe",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629969,
+    "wof:lastmodified":1582318815,
     "wof:name":"Shemgang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/63/85669563.geojson
+++ b/data/856/695/63/85669563.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Trongsa District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7be5be79422b54d1038b3902c93559c2",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629973,
+    "wof:lastmodified":1582318816,
     "wof:name":"Tongsa",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/65/85669565.geojson
+++ b/data/856/695/65/85669565.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"BT-24"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03d38e2ac40e516837102c1946e8e88e",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629972,
+    "wof:lastmodified":1582318816,
     "wof:name":"Wangdi Phodrang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/71/85669571.geojson
+++ b/data/856/695/71/85669571.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Mongar District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a573511b84ed777649ef0af5d864759e",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629975,
+    "wof:lastmodified":1582318817,
     "wof:name":"Mongar",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/75/85669575.geojson
+++ b/data/856/695/75/85669575.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Pemagatshel District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8719792ce2bec0e4a6807e9b9496a7c",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629971,
+    "wof:lastmodified":1582318815,
     "wof:name":"Pemagatshel",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/79/85669579.geojson
+++ b/data/856/695/79/85669579.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Samdrup Jongkhar District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b11d994fb3de2322ca84d5e7e816e556",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629973,
+    "wof:lastmodified":1582318816,
     "wof:name":"Samdrup Jongkhar",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/83/85669583.geojson
+++ b/data/856/695/83/85669583.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Trashigang District"
     },
     "wof:country":"BT",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"591f14e747ec5a5417a7a8376822b417",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1566629974,
+    "wof:lastmodified":1582318816,
     "wof:name":"Tashigang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.