### PR TITLE
bt concordances, placetype local, and more

### DIFF
--- a/data/110/874/724/9/1108747249.geojson
+++ b/data/110/874/724/9/1108747249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070725,
-    "geom:area_square_m":777208348.05874,
+    "geom:area_square_m":777208392.48399,
     "geom:bbox":"89.963183,27.145594,90.375753,27.425596",
     "geom:latitude":27.287136,
     "geom:longitude":90.178662,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326485,
-    "wof:geomhash":"4e2b081adaf7795cff099f7d49628991",
+    "wof:geomhash":"4d2249ddea76e89de4b4807162f38128",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747249,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Athang",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/726/3/1108747263.geojson
+++ b/data/110/874/726/3/1108747263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001978,
-    "geom:area_square_m":21809592.758857,
+    "geom:area_square_m":21809502.283031,
     "geom:bbox":"90.038838,26.911272,90.102403,26.966196",
     "geom:latitude":26.934404,
     "geom:longitude":90.070397,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326486,
-    "wof:geomhash":"918716da6e7b560057d1f9b81b93fbf2",
+    "wof:geomhash":"69f69e11e6ada663921a1819f4acdf99",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747263,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Barzhong",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/726/5/1108747265.geojson
+++ b/data/110/874/726/5/1108747265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015408,
-    "geom:area_square_m":169915498.969326,
+    "geom:area_square_m":169915639.217589,
     "geom:bbox":"90.006377,26.818505,90.21536,26.986844",
     "geom:latitude":26.897657,
     "geom:longitude":90.102908,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326487,
-    "wof:geomhash":"44ad3f3c9b78df3ec1d6d3a73ec628be",
+    "wof:geomhash":"5188b209a72f7e2d7e67b104df9858c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108747265,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Beteni",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/726/7/1108747267.geojson
+++ b/data/110/874/726/7/1108747267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004946,
-    "geom:area_square_m":54530956.462326,
+    "geom:area_square_m":54530975.362522,
     "geom:bbox":"90.390984,26.871397,90.472381,26.979926",
     "geom:latitude":26.928638,
     "geom:longitude":90.432653,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326487,
-    "wof:geomhash":"5509009a9a81aca39f02c019c2a14f25",
+    "wof:geomhash":"33dc43365bde5ea239224a978156f664",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108747267,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Bhur",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/727/3/1108747273.geojson
+++ b/data/110/874/727/3/1108747273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004677,
-    "geom:area_square_m":51495896.508082,
+    "geom:area_square_m":51495867.349273,
     "geom:bbox":"88.873883,27.003985,88.951,27.111473",
     "geom:latitude":27.065375,
     "geom:longitude":88.912754,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326487,
-    "wof:geomhash":"c7d06bca19d2c2c45c564843fa125779",
+    "wof:geomhash":"570a0f1fea59cb091098037d2d372d0e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108747273,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Biru",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/727/5/1108747275.geojson
+++ b/data/110/874/727/5/1108747275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012838,
-    "geom:area_square_m":141345402.392058,
+    "geom:area_square_m":141345573.817187,
     "geom:bbox":"89.50627,27.00114,89.664676,27.14872",
     "geom:latitude":27.074207,
     "geom:longitude":89.582137,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326487,
-    "wof:geomhash":"db15905b498429ccd7cf71c1c63f9a1b",
+    "wof:geomhash":"28b3c1f5ad013fdcdaf16b7452ea8fe4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747275,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Bjachho",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/727/7/1108747277.geojson
+++ b/data/110/874/727/7/1108747277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010846,
-    "geom:area_square_m":118993198.951513,
+    "geom:area_square_m":118993357.464168,
     "geom:bbox":"89.944528,27.401446,90.127215,27.524973",
     "geom:latitude":27.47018,
     "geom:longitude":90.033521,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326488,
-    "wof:geomhash":"e66fe6a8b845ea6b913a80a549694768",
+    "wof:geomhash":"3376fff1f01c1aa2f9d5a68d6bbde51a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747277,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886212,
     "wof:name":"Bjena",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/727/9/1108747279.geojson
+++ b/data/110/874/727/9/1108747279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059697,
-    "geom:area_square_m":655153592.041703,
+    "geom:area_square_m":655153331.521107,
     "geom:bbox":"88.95073,27.284258,89.293976,27.613511",
     "geom:latitude":27.434395,
     "geom:longitude":89.11812,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"BT.HA.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326488,
-    "wof:geomhash":"2ab4640c164304155ff83084b34e2682",
+    "wof:geomhash":"49c2bd882f79cfd5960cb427a99e3606",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108747279,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886206,
     "wof:name":"Biji",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/110/874/728/1/1108747281.geojson
+++ b/data/110/874/728/1/1108747281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017746,
-    "geom:area_square_m":195584040.550055,
+    "geom:area_square_m":195584035.40344,
     "geom:bbox":"90.984556,26.867897,91.180865,27.059906",
     "geom:latitude":26.959036,
     "geom:longitude":91.084175,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.BJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326488,
-    "wof:geomhash":"0c352e01b2f92895b47365ea3432f95b",
+    "wof:geomhash":"fe06d13e9a4e68d142c715533aa50c4d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747281,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886207,
     "wof:name":"Bjoka",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/728/3/1108747283.geojson
+++ b/data/110/874/728/3/1108747283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036169,
-    "geom:area_square_m":398751397.899077,
+    "geom:area_square_m":398751397.89914,
     "geom:bbox":"89.5020232151,26.7661177333,89.7579561057,27.0801963782",
     "geom:latitude":26.925249,
     "geom:longitude":89.629389,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326488,
-    "wof:geomhash":"38e823d58a6918ff373efb826b7ffeb5",
+    "wof:geomhash":"f93c8e65f0446a34aa406b623848af82",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108747283,
-    "wof:lastmodified":1566630041,
+    "wof:lastmodified":1695886272,
     "wof:name":"Bongo",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/728/5/1108747285.geojson
+++ b/data/110/874/728/5/1108747285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077516,
-    "geom:area_square_m":848036496.704572,
+    "geom:area_square_m":848036610.640352,
     "geom:bbox":"91.343819,27.601165,91.644836,27.980017",
     "geom:latitude":27.778719,
     "geom:longitude":91.480792,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326488,
-    "wof:geomhash":"27825adbd1b7ba7caf8031d7421dffca",
+    "wof:geomhash":"7b86fcb116805d705ebd3c3de8dc86b8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747285,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886207,
     "wof:name":"Bumdeling",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/728/9/1108747289.geojson
+++ b/data/110/874/728/9/1108747289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014279,
-    "geom:area_square_m":156688532.766737,
+    "geom:area_square_m":156688532.766749,
     "geom:bbox":"89.5677082203,27.359807481,89.7618445056,27.52480362",
     "geom:latitude":27.446886,
     "geom:longitude":89.676154,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326489,
-    "wof:geomhash":"f91fdab18a37f9e388b357a8a864daf8",
+    "wof:geomhash":"89424566211689e32d64d9c5f591279b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108747289,
-    "wof:lastmodified":1566630041,
+    "wof:lastmodified":1695886272,
     "wof:name":"Chang",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/729/1/1108747291.geojson
+++ b/data/110/874/729/1/1108747291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011795,
-    "geom:area_square_m":129715567.68165,
+    "geom:area_square_m":129715507.986897,
     "geom:bbox":"89.51463,27.108132,89.62885,27.315521",
     "geom:latitude":27.206542,
     "geom:longitude":89.561785,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326489,
-    "wof:geomhash":"f89f1e4dac56a5929305e7b39dfe56be",
+    "wof:geomhash":"55f8e73aabc4c175b1566792d74f8f24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747291,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886207,
     "wof:name":"Chapchha",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/729/3/1108747293.geojson
+++ b/data/110/874/729/3/1108747293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00343,
-    "geom:area_square_m":37785942.349955,
+    "geom:area_square_m":37785894.695915,
     "geom:bbox":"88.921544,26.95662,89.01867,27.032643",
     "geom:latitude":26.996832,
     "geom:longitude":88.971808,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326489,
-    "wof:geomhash":"8ade2f6414b89f789b3469c09c4a8a4a",
+    "wof:geomhash":"8a59b729bb65be9a9e803b3f475ef36e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747293,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886207,
     "wof:name":"Chargharay",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/729/5/1108747295.geojson
+++ b/data/110/874/729/5/1108747295.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326489,
     "wof:geomhash":"1d204b543d765a651ba3cd29d005d563",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108747295,
-    "wof:lastmodified":1694492837,
+    "wof:lastmodified":1695886276,
     "wof:name":"Chaskhar",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/729/7/1108747297.geojson
+++ b/data/110/874/729/7/1108747297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010629,
-    "geom:area_square_m":117114809.342706,
+    "geom:area_square_m":117114756.085243,
     "geom:bbox":"89.011798,26.916923,89.114771,27.067821",
     "geom:latitude":26.992877,
     "geom:longitude":89.062348,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326489,
-    "wof:geomhash":"39c2b694825d1d39471791900f66aa50",
+    "wof:geomhash":"ff199a80194d0215e0a499263d6e5f96",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747297,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chengmari",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/729/9/1108747299.geojson
+++ b/data/110/874/729/9/1108747299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002267,
-    "geom:area_square_m":24911967.679316,
+    "geom:area_square_m":24912043.818287,
     "geom:bbox":"91.191311,27.259001,91.279242,27.33028",
     "geom:latitude":27.305092,
     "geom:longitude":91.233138,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326490,
-    "wof:geomhash":"ee0aff74d00ad646318bc4a43720d06c",
+    "wof:geomhash":"2ccebdf4fb94067c5569d587513e606c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747299,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chhali",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/730/1/1108747301.geojson
+++ b/data/110/874/730/1/1108747301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004803,
-    "geom:area_square_m":52902252.663908,
+    "geom:area_square_m":52902277.974278,
     "geom:bbox":"91.222284,26.998503,91.350706,27.082238",
     "geom:latitude":27.038827,
     "geom:longitude":91.285515,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326490,
-    "wof:geomhash":"50ff79a83925f6176d96c7ef36c6bdaa",
+    "wof:geomhash":"7ac8eae6124b118779db402a29b97a32",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747301,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chhimung",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/730/9/1108747309.geojson
+++ b/data/110/874/730/9/1108747309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036756,
-    "geom:area_square_m":403293514.623749,
+    "geom:area_square_m":403293439.544245,
     "geom:bbox":"90.568504,27.335471,90.913069,27.593257",
     "geom:latitude":27.459148,
     "geom:longitude":90.730115,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.BU.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326491,
-    "wof:geomhash":"64446b02c5e3febe3509b4ff72cbcfe0",
+    "wof:geomhash":"365ddfb5e97d42bff99736fde1e62399",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747309,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chhume",
     "wof:parent_id":85669537,
     "wof:placetype":"county",

--- a/data/110/874/731/1/1108747311.geojson
+++ b/data/110/874/731/1/1108747311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001937,
-    "geom:area_square_m":21369269.825289,
+    "geom:area_square_m":21369183.111373,
     "geom:bbox":"90.501726,26.838111,90.551138,26.9129",
     "geom:latitude":26.87356,
     "geom:longitude":90.521461,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.CZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326491,
-    "wof:geomhash":"9a574c8750e5a73ac72b3622e820f0c7",
+    "wof:geomhash":"9e9833a4bcf09acc5c05663da83b43cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747311,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chhuzagang",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/731/3/1108747313.geojson
+++ b/data/110/874/731/3/1108747313.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326491,
     "wof:geomhash":"5b76d8274ccef727fa8fe37ceeca3b2e",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108747313,
-    "wof:lastmodified":1694492838,
+    "wof:lastmodified":1695886277,
     "wof:name":"Chokhorling",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/731/5/1108747315.geojson
+++ b/data/110/874/731/5/1108747315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002841,
-    "geom:area_square_m":31303363.152087,
+    "geom:area_square_m":31303366.265937,
     "geom:bbox":"91.305062,26.960612,91.398304,27.041332",
     "geom:latitude":27.004466,
     "geom:longitude":91.358164,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326491,
-    "wof:geomhash":"75dfb91dd50f2385127358708f39dbd3",
+    "wof:geomhash":"9b78be1be28c34c978dce23ebc77e231",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747315,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Chongshing",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/731/7/1108747317.geojson
+++ b/data/110/874/731/7/1108747317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018573,
-    "geom:area_square_m":204104659.039884,
+    "geom:area_square_m":204104805.549867,
     "geom:bbox":"89.576517,27.145278,89.762991,27.430064",
     "geom:latitude":27.284561,
     "geom:longitude":89.667635,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326492,
-    "wof:geomhash":"fb7264a6c737a6bc89e8df6253edbdf5",
+    "wof:geomhash":"ccfe1622ef37b3bc21d3cdaafb77c3df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747317,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Dagala",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/731/9/1108747319.geojson
+++ b/data/110/874/731/9/1108747319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031523,
-    "geom:area_square_m":346562089.729845,
+    "geom:area_square_m":346562232.475604,
     "geom:bbox":"89.786036,27.123211,90.072979,27.342691",
     "geom:latitude":27.238654,
     "geom:longitude":89.95331,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326492,
-    "wof:geomhash":"8c826ccb49a61c16308fd51085b1a91a",
+    "wof:geomhash":"88e83eff82c4f23ccaf1522859ff3f8e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108747319,
-    "wof:lastmodified":1636495664,
+    "wof:lastmodified":1695886659,
     "wof:name":"Daga",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/732/1/1108747321.geojson
+++ b/data/110/874/732/1/1108747321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012358,
-    "geom:area_square_m":136402422.457629,
+    "geom:area_square_m":136402422.457903,
     "geom:bbox":"89.5220823306,26.717506,89.7490764282,26.9109934325",
     "geom:latitude":26.797928,
     "geom:longitude":89.629495,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326492,
-    "wof:geomhash":"6ca38905d2f4512fc3cf701f9b747494",
+    "wof:geomhash":"04b944d78169f9cfecad5a83a11c6932",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108747321,
-    "wof:lastmodified":1566630020,
+    "wof:lastmodified":1695886271,
     "wof:name":"Dala",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/732/7/1108747327.geojson
+++ b/data/110/874/732/7/1108747327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01235,
-    "geom:area_square_m":136172318.025883,
+    "geom:area_square_m":136172307.7461,
     "geom:bbox":"91.15555,26.84886,91.321583,26.960974",
     "geom:latitude":26.907441,
     "geom:longitude":91.240918,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326492,
-    "wof:geomhash":"992eb4d3e0a599b1414f9d149b26c106",
+    "wof:geomhash":"e274e7e5a29a8f542895a0f92af37ec7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108747327,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886208,
     "wof:name":"Dechhenling",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/874/733/9/1108747339.geojson
+++ b/data/110/874/733/9/1108747339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009682,
-    "geom:area_square_m":106390774.259459,
+    "geom:area_square_m":106390757.956371,
     "geom:bbox":"89.41895,27.226515,89.550493,27.362874",
     "geom:latitude":27.292142,
     "geom:longitude":89.495992,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326494,
-    "wof:geomhash":"d7d4c094558832d29064a69ae05677a4",
+    "wof:geomhash":"d5bfd6a393541b1da9ea08563949b778",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108747339,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886208,
     "wof:name":"Doga",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/734/3/1108747343.geojson
+++ b/data/110/874/734/3/1108747343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003023,
-    "geom:area_square_m":33176538.598395,
+    "geom:area_square_m":33176604.988591,
     "geom:bbox":"89.395951,27.425821,89.482877,27.478548",
     "geom:latitude":27.450208,
     "geom:longitude":89.442276,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326494,
-    "wof:geomhash":"b99c64219a4aa6818200421bbe76fc43",
+    "wof:geomhash":"fcb6c9d165b53aa962c30b3fe3ea9bc5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747343,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Dopshari",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/734/5/1108747345.geojson
+++ b/data/110/874/734/5/1108747345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009468,
-    "geom:area_square_m":104340312.474722,
+    "geom:area_square_m":104340315.413111,
     "geom:bbox":"89.107321,26.919031,89.27288,27.023002",
     "geom:latitude":26.969999,
     "geom:longitude":89.197003,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326494,
-    "wof:geomhash":"45aaf1b0223e9ddcec74a76707a48fa6",
+    "wof:geomhash":"1596f806d6026d8edd7f700f42ca648b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747345,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Dorokha",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/734/7/1108747347.geojson
+++ b/data/110/874/734/7/1108747347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00978,
-    "geom:area_square_m":107873711.839733,
+    "geom:area_square_m":107873589.87181,
     "geom:bbox":"89.772398,26.806728,89.911313,26.942189",
     "geom:latitude":26.869833,
     "geom:longitude":89.837027,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326494,
-    "wof:geomhash":"da367913b7b25225f067c668fa102b78",
+    "wof:geomhash":"d6ad1725cf8b658b6ec6fdb691974cb8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747347,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Dorona",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/735/1/1108747351.geojson
+++ b/data/110/874/735/1/1108747351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007837,
-    "geom:area_square_m":86006313.951612,
+    "geom:area_square_m":86006360.463704,
     "geom:bbox":"90.463918,27.367969,90.592838,27.482934",
     "geom:latitude":27.433598,
     "geom:longitude":90.525838,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TO.DT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326495,
-    "wof:geomhash":"565213e82b6d514d6235584818208669",
+    "wof:geomhash":"74affe334b724fff1ff7e986738e0e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747351,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Dragteng",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/110/874/735/3/1108747353.geojson
+++ b/data/110/874/735/3/1108747353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002637,
-    "geom:area_square_m":28964495.64283,
+    "geom:area_square_m":28964445.715862,
     "geom:bbox":"91.418285,27.304922,91.4974,27.388345",
     "geom:latitude":27.34122,
     "geom:longitude":91.460945,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326495,
-    "wof:geomhash":"701c0e4d6a213f511bf9898438460b10",
+    "wof:geomhash":"8b8c800bd8552a51a20524901a014060",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747353,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Drametse",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/735/5/1108747355.geojson
+++ b/data/110/874/735/5/1108747355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004722,
-    "geom:area_square_m":51922685.516255,
+    "geom:area_square_m":51922665.189199,
     "geom:bbox":"91.198528,27.171602,91.304396,27.241177",
     "geom:latitude":27.210969,
     "geom:longitude":91.254678,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.DP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326495,
-    "wof:geomhash":"436cd96ddff361715dfc79c0b7e43e54",
+    "wof:geomhash":"3572d126cd277cc4c10e2b0436379a4b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747355,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886209,
     "wof:name":"Drepung",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/735/7/1108747357.geojson
+++ b/data/110/874/735/7/1108747357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00523,
-    "geom:area_square_m":57626937.703079,
+    "geom:area_square_m":57626876.869176,
     "geom:bbox":"89.988122,26.930391,90.070726,27.042439",
     "geom:latitude":26.981897,
     "geom:longitude":90.027852,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.DJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326496,
-    "wof:geomhash":"e76993427f01232b216f46c71f5e40f2",
+    "wof:geomhash":"34f4e196aa1aaeb9122b1cbc94e7e86e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747357,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Drugyelgang",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/736/9/1108747369.geojson
+++ b/data/110/874/736/9/1108747369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002031,
-    "geom:area_square_m":22255246.788038,
+    "geom:area_square_m":22255247.991115,
     "geom:bbox":"89.863384,27.547219,89.905706,27.615964",
     "geom:latitude":27.581557,
     "geom:longitude":89.885511,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.DZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326496,
-    "wof:geomhash":"4699510e56263762f55798437dd5b068",
+    "wof:geomhash":"5478ebb1c282b127975159997d74d4ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747369,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Dzoma",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/739/1/1108747391.geojson
+++ b/data/110/874/739/1/1108747391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022014,
-    "geom:area_square_m":242683249.802871,
+    "geom:area_square_m":242683312.260277,
     "geom:bbox":"89.66954,26.795578,89.824569,27.043251",
     "geom:latitude":26.934121,
     "geom:longitude":89.738113,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326499,
-    "wof:geomhash":"41e9415f97cd10908595215118866c58",
+    "wof:geomhash":"b08a7c67f5889ca529ce256e39ec55cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747391,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Getana",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/739/3/1108747393.geojson
+++ b/data/110/874/739/3/1108747393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013731,
-    "geom:area_square_m":150211761.928617,
+    "geom:area_square_m":150211854.986554,
     "geom:bbox":"89.578255,27.723609,89.739819,27.865392",
     "geom:latitude":27.784269,
     "geom:longitude":89.672285,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GA.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326499,
-    "wof:geomhash":"15191630de039a484e277a61b183fd05",
+    "wof:geomhash":"5cbbcd7955c11a28b40c40b5e24b43b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747393,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Goenkhame",
     "wof:parent_id":85669521,
     "wof:placetype":"county",

--- a/data/110/874/739/7/1108747397.geojson
+++ b/data/110/874/739/7/1108747397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026364,
-    "geom:area_square_m":288176174.888956,
+    "geom:area_square_m":288176148.971934,
     "geom:bbox":"89.507069,27.759419,89.74247,27.97364",
     "geom:latitude":27.873183,
     "geom:longitude":89.608519,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GA.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326499,
-    "wof:geomhash":"fcb9ebad2af5095cccc795b7c5df243a",
+    "wof:geomhash":"819ae1ff4a36f672861ae88b4a7bcab4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747397,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Goenkhatoe",
     "wof:parent_id":85669521,
     "wof:placetype":"county",

--- a/data/110/874/739/9/1108747399.geojson
+++ b/data/110/874/739/9/1108747399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008128,
-    "geom:area_square_m":88966373.184194,
+    "geom:area_square_m":88966287.679633,
     "geom:bbox":"89.699145,27.661072,89.835071,27.776589",
     "geom:latitude":27.724937,
     "geom:longitude":89.772852,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326499,
-    "wof:geomhash":"628cbc8b608ae4f4ebb63073d7e85959",
+    "wof:geomhash":"ba575bc4ea259a0276caca9e981f0907",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747399,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Goenshari",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/740/1/1108747401.geojson
+++ b/data/110/874/740/1/1108747401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007395,
-    "geom:area_square_m":81467042.345531,
+    "geom:area_square_m":81467082.849169,
     "geom:bbox":"91.517893,26.941024,91.644077,27.06029",
     "geom:latitude":27.007237,
     "geom:longitude":91.574631,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326499,
-    "wof:geomhash":"802df1d3a3b7199536a9bba1d625d0b3",
+    "wof:geomhash":"d2b4508552c92fe10f5b5d2bf7196d45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747401,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Gomdar",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/740/3/1108747403.geojson
+++ b/data/110/874/740/3/1108747403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016889,
-    "geom:area_square_m":186009027.685025,
+    "geom:area_square_m":186009023.401929,
     "geom:bbox":"91.087573,26.941623,91.2352,27.133739",
     "geom:latitude":27.04056,
     "geom:longitude":91.160251,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326500,
-    "wof:geomhash":"d878cb1247812e15749308fa34b145a6",
+    "wof:geomhash":"ee1b4b1957c445fcb5e361f24350b68b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747403,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Gongdue",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/740/5/1108747405.geojson
+++ b/data/110/874/740/5/1108747405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000918,
-    "geom:area_square_m":10108168.947838,
+    "geom:area_square_m":10108139.425113,
     "geom:bbox":"90.09621,27.017479,90.148227,27.043679",
     "geom:latitude":27.031482,
     "geom:longitude":90.120689,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326500,
-    "wof:geomhash":"3258952152ef3f2a85f14fcd423f3847",
+    "wof:geomhash":"8b2bc51dbadc9f7f7441a656388d48e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747405,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Gosarling",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/740/7/1108747407.geojson
+++ b/data/110/874/740/7/1108747407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001978,
-    "geom:area_square_m":21803508.634486,
+    "geom:area_square_m":21803566.58831,
     "geom:bbox":"89.904166,26.90545,89.956885,26.967847",
     "geom:latitude":26.939067,
     "geom:longitude":89.935438,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.GZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326500,
-    "wof:geomhash":"dd719ecd52d079c5073d11f7cd77502a",
+    "wof:geomhash":"8eff4c24a78b23fa74873752cc5b1902",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747407,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Gozhi",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/740/9/1108747409.geojson
+++ b/data/110/874/740/9/1108747409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00906,
-    "geom:area_square_m":99842112.457355,
+    "geom:area_square_m":99841925.802397,
     "geom:bbox":"90.853445,26.902098,90.984589,27.021417",
     "geom:latitude":26.967329,
     "geom:longitude":90.916843,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326501,
-    "wof:geomhash":"0c79eb50ff1fe463259618ec5616aced",
+    "wof:geomhash":"a0a020e533857c2aaced049141ce9fcb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747409,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Gozhing",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/741/5/1108747415.geojson
+++ b/data/110/874/741/5/1108747415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013004,
-    "geom:area_square_m":143345880.669007,
+    "geom:area_square_m":143345798.169589,
     "geom:bbox":"90.195682,26.854325,90.325189,27.010298",
     "geom:latitude":26.939988,
     "geom:longitude":90.258474,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.HL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326501,
-    "wof:geomhash":"72915cc173a70ee10e45b5cf8fef3f98",
+    "wof:geomhash":"e65fc42c1e5f1c12057ac60474a4420f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747415,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886211,
     "wof:name":"Hiley",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/741/7/1108747417.geojson
+++ b/data/110/874/741/7/1108747417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001065,
-    "geom:area_square_m":11694548.485389,
+    "geom:area_square_m":11694566.904992,
     "geom:bbox":"89.420247,27.399789,89.487096,27.435561",
     "geom:latitude":27.420169,
     "geom:longitude":89.457916,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.HR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326501,
-    "wof:geomhash":"c022fc370a682b4eeb67765aedbb6bff",
+    "wof:geomhash":"5ccfcf2e053863a100b4cc964d5f54ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747417,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886212,
     "wof:name":"Hungrel",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/741/9/1108747419.geojson
+++ b/data/110/874/741/9/1108747419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004677,
-    "geom:area_square_m":51341817.96645,
+    "geom:area_square_m":51341749.323815,
     "geom:bbox":"91.429797,27.37515,91.560443,27.442818",
     "geom:latitude":27.412876,
     "geom:longitude":91.500643,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.JK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326501,
-    "wof:geomhash":"e12d2bf36ef3b190f077350337d44540",
+    "wof:geomhash":"b740f2d9808f657497659bb2200c291d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747419,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Jamkhar",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/742/1/1108747421.geojson
+++ b/data/110/874/742/1/1108747421.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108747421,
-    "wof:lastmodified":1694492851,
+    "wof:lastmodified":1695886309,
     "wof:name":"Jangchhubling",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/744/7/1108747447.geojson
+++ b/data/110/874/744/7/1108747447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014171,
-    "geom:area_square_m":155861713.834092,
+    "geom:area_square_m":155861711.822979,
     "geom:bbox":"91.439022,27.109532,91.656639,27.247877",
     "geom:latitude":27.194555,
     "geom:longitude":91.572502,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326504,
-    "wof:geomhash":"102bc95be52764fec88c1240f0adb65f",
+    "wof:geomhash":"050b9aec822604fe844ecfd01a210091",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747447,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Khaling",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/745/1/1108747451.geojson
+++ b/data/110/874/745/1/1108747451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004083,
-    "geom:area_square_m":44784209.146713,
+    "geom:area_square_m":44784144.28686,
     "geom:bbox":"91.512011,27.43573,91.593624,27.542715",
     "geom:latitude":27.49399,
     "geom:longitude":91.554966,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326504,
-    "wof:geomhash":"b6e531f28e81ec11fa5fe0fefcdd87e4",
+    "wof:geomhash":"dfe44045f28e9ae64e9faed64e210e1f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747451,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Khamdang",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/745/3/1108747453.geojson
+++ b/data/110/874/745/3/1108747453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010378,
-    "geom:area_square_m":114396594.558181,
+    "geom:area_square_m":114396588.802224,
     "geom:bbox":"91.329961,26.874332,91.461892,27.016296",
     "geom:latitude":26.946736,
     "geom:longitude":91.395458,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326505,
-    "wof:geomhash":"9152fe0f0ebb86919221f200081a1e49",
+    "wof:geomhash":"dcb68b0491a8f8245f2539301be56ef3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108747453,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Khar",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/745/5/1108747455.geojson
+++ b/data/110/874/745/5/1108747455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008754,
-    "geom:area_square_m":96414293.77432,
+    "geom:area_square_m":96414376.890107,
     "geom:bbox":"89.893542,26.950361,90.002732,27.124993",
     "geom:latitude":27.034381,
     "geom:longitude":89.952182,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326505,
-    "wof:geomhash":"f18eee7437b5198668c0505f240923ea",
+    "wof:geomhash":"29b24cbaf5afaa952c7c7b1eff899088",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747455,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Khipisa",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/745/7/1108747457.geojson
+++ b/data/110/874/745/7/1108747457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060959,
-    "geom:area_square_m":666503778.911228,
+    "geom:area_square_m":666503778.911197,
     "geom:bbox":"91.179790181,27.6081794583,91.4748265907,28.0710885",
     "geom:latitude":27.843195,
     "geom:longitude":91.308574,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326505,
-    "wof:geomhash":"afbe29f06f795cac4b12f8b27b832259",
+    "wof:geomhash":"73d0af6fd0ad1b79a5001e11b4ac5a1e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108747457,
-    "wof:lastmodified":1566630042,
+    "wof:lastmodified":1695886272,
     "wof:name":"Khoma",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/747/1/1108747471.geojson
+++ b/data/110/874/747/1/1108747471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019465,
-    "geom:area_square_m":214619077.702525,
+    "geom:area_square_m":214619026.852859,
     "geom:bbox":"91.880168,26.849616,92.121346,26.989833",
     "geom:latitude":26.916709,
     "geom:longitude":92.023839,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.LC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326510,
-    "wof:geomhash":"1072866398452f1eb960bbf0d96627e5",
+    "wof:geomhash":"6d4a6c038194e1aefdc1c7e58ba708f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747471,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Langchhenphu",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/747/3/1108747473.geojson
+++ b/data/110/874/747/3/1108747473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046277,
-    "geom:area_square_m":508347642.802583,
+    "geom:area_square_m":508347554.614625,
     "geom:bbox":"90.364892,27.218925,90.749246,27.459528",
     "geom:latitude":27.331467,
     "geom:longitude":90.598116,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TO.LT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326511,
-    "wof:geomhash":"7a351c60fea594c407bef0577b02602a",
+    "wof:geomhash":"14df8f3f4b84e50862449ee0090f7740",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747473,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Langthil",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/110/874/747/5/1108747475.geojson
+++ b/data/110/874/747/5/1108747475.geojson
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.LR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326511,
-    "wof:geomhash":"87c98e3b8728cc2af61f6f15283461ba",
+    "wof:geomhash":"61f266db3a863d6566be8af6d73e6f8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108747475,
-    "wof:lastmodified":1566630011,
+    "wof:lastmodified":1695886271,
     "wof:name":"Lauri",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/747/7/1108747477.geojson
+++ b/data/110/874/747/7/1108747477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087958,
-    "geom:area_square_m":959737284.17532,
+    "geom:area_square_m":959737273.555547,
     "geom:bbox":"89.451154,27.895069,89.898225,28.246987",
     "geom:latitude":28.064004,
     "geom:longitude":89.708189,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GA.LY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326511,
-    "wof:geomhash":"823f49b849f037e4370267b38d084d64",
+    "wof:geomhash":"f1fcb55e26aec3f3430fc6e9c711995e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108747477,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886214,
     "wof:name":"Laya",
     "wof:parent_id":85669521,
     "wof:placetype":"county",

--- a/data/110/874/747/9/1108747479.geojson
+++ b/data/110/874/747/9/1108747479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009541,
-    "geom:area_square_m":105350184.02204,
+    "geom:area_square_m":105350033.617824,
     "geom:bbox":"89.734862,26.702016,89.863881,26.817423",
     "geom:latitude":26.753862,
     "geom:longitude":89.795737,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326511,
-    "wof:geomhash":"fd5f6af7421481591d6a21cb73eb6d5e",
+    "wof:geomhash":"e6f2ed57771d13c1a370be5145350ead",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747479,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lhamoizingkha",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/749/1/1108747491.geojson
+++ b/data/110/874/749/1/1108747491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159353,
-    "geom:area_square_m":1739748060.530761,
+    "geom:area_square_m":1739748042.663174,
     "geom:bbox":"89.727742,27.751026,90.455649,28.194563",
     "geom:latitude":28.002101,
     "geom:longitude":90.063943,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GA.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326512,
-    "wof:geomhash":"8bf200f75e30b6e91efa7773aaa9a27b",
+    "wof:geomhash":"802be8046c89872801af537567009e36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108747491,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lunana",
     "wof:parent_id":85669521,
     "wof:placetype":"county",

--- a/data/110/874/749/3/1108747493.geojson
+++ b/data/110/874/749/3/1108747493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006933,
-    "geom:area_square_m":76133077.081262,
+    "geom:area_square_m":76133099.134598,
     "geom:bbox":"89.33215,27.318187,89.454364,27.441361",
     "geom:latitude":27.372483,
     "geom:longitude":89.390308,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326512,
-    "wof:geomhash":"0ea547350464e0b1d14e12324ab326dc",
+    "wof:geomhash":"d7e321648769315fd26dfb9ad30746cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747493,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lungnyi",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/749/5/1108747495.geojson
+++ b/data/110/874/749/5/1108747495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026954,
-    "geom:area_square_m":296974841.325646,
+    "geom:area_square_m":296974826.396597,
     "geom:bbox":"91.608464,26.890362,91.862873,27.090824",
     "geom:latitude":26.99542,
     "geom:longitude":91.735641,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326513,
-    "wof:geomhash":"384edd186e3069cfbfd5c081b881f059",
+    "wof:geomhash":"4d911970414569c759b0892fe455bd71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747495,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Martshala",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/749/7/1108747497.geojson
+++ b/data/110/874/749/7/1108747497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00817,
-    "geom:area_square_m":89530740.34868,
+    "geom:area_square_m":89530725.381603,
     "geom:bbox":"91.111639,27.531798,91.219668,27.662069",
     "geom:latitude":27.594362,
     "geom:longitude":91.170563,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326513,
-    "wof:geomhash":"f88e8908b8bfdc92fe5e610aeb406762",
+    "wof:geomhash":"f082a4d3e25a1e9ca3b110522237bff0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747497,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Menbi",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/749/9/1108747499.geojson
+++ b/data/110/874/749/9/1108747499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001249,
-    "geom:area_square_m":13770840.175203,
+    "geom:area_square_m":13770934.91097,
     "geom:bbox":"90.080603,26.9346,90.146077,26.975967",
     "geom:latitude":26.953975,
     "geom:longitude":90.114414,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326513,
-    "wof:geomhash":"e5483727f657305c14e843f9f49fff8e",
+    "wof:geomhash":"faedf15be0fc26cf2f8c63b2cec08e43",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747499,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Mendrelgang",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/750/1/1108747501.geojson
+++ b/data/110/874/750/1/1108747501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04128,
-    "geom:area_square_m":453762455.524506,
+    "geom:area_square_m":453762455.524313,
     "geom:bbox":"91.7168426623,27.1443004186,92.1227122484,27.3615141652",
     "geom:latitude":27.254663,
     "geom:longitude":91.897277,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326513,
-    "wof:geomhash":"d59e031f7327750ab812087bbb850534",
+    "wof:geomhash":"0fec4b3dac15457de4b8f97cbe474a80",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108747501,
-    "wof:lastmodified":1566630021,
+    "wof:lastmodified":1695886271,
     "wof:name":"Merak",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/750/5/1108747505.geojson
+++ b/data/110/874/750/5/1108747505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011842,
-    "geom:area_square_m":130340234.595737,
+    "geom:area_square_m":130340175.161625,
     "geom:bbox":"89.374881,27.035746,89.487728,27.194927",
     "geom:latitude":27.106124,
     "geom:longitude":89.433036,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326514,
-    "wof:geomhash":"3b69342fc80dba7ae526fb25a263fcc3",
+    "wof:geomhash":"acc2c9d3045fd428786d76c75ae7e944",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747505,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Metap",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/750/7/1108747507.geojson
+++ b/data/110/874/750/7/1108747507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02003,
-    "geom:area_square_m":219605991.475854,
+    "geom:area_square_m":219606092.828748,
     "geom:bbox":"90.972698,27.472023,91.179468,27.62281",
     "geom:latitude":27.542962,
     "geom:longitude":91.064483,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326514,
-    "wof:geomhash":"df90d2c24e4120aa9872734224ac0a33",
+    "wof:geomhash":"53382ca7eda26317a6f0d750357cbd3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747507,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Metsho",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/750/9/1108747509.geojson
+++ b/data/110/874/750/9/1108747509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020985,
-    "geom:area_square_m":230318038.514686,
+    "geom:area_square_m":230317921.068119,
     "geom:bbox":"89.479185,27.315513,89.65312,27.567233",
     "geom:latitude":27.424371,
     "geom:longitude":89.554673,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326514,
-    "wof:geomhash":"5afd0839d0a90002f609335fbb3da725",
+    "wof:geomhash":"0595be131a2d0dd9e95718990b432d9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747509,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Mewang",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/751/1/1108747511.geojson
+++ b/data/110/874/751/1/1108747511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01258,
-    "geom:area_square_m":137877330.934567,
+    "geom:area_square_m":137877299.457724,
     "geom:bbox":"91.191626,27.51387,91.337593,27.652176",
     "geom:latitude":27.580166,
     "geom:longitude":91.261037,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326514,
-    "wof:geomhash":"8267cd9d56d047d9b9bdaeff1f930807",
+    "wof:geomhash":"e9a616bdc3eb7e4bd973548c2c021974",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747511,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886216,
     "wof:name":"Minjay",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/751/3/1108747513.geojson
+++ b/data/110/874/751/3/1108747513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006661,
-    "geom:area_square_m":73212568.711197,
+    "geom:area_square_m":73212521.395657,
     "geom:bbox":"91.190185,27.219633,91.313503,27.316954",
     "geom:latitude":27.265658,
     "geom:longitude":91.251714,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326514,
-    "wof:geomhash":"5bfb11c4903d013d90f730125f34ba49",
+    "wof:geomhash":"44105fc4ce2d4782a2fbf070d2003c6b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108747513,
-    "wof:lastmodified":1636495664,
+    "wof:lastmodified":1695886660,
     "wof:name":"Mongar",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/751/5/1108747515.geojson
+++ b/data/110/874/751/5/1108747515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006195,
-    "geom:area_square_m":67980895.252707,
+    "geom:area_square_m":67980788.78438,
     "geom:bbox":"89.753757,27.406065,89.887149,27.481838",
     "geom:latitude":27.447551,
     "geom:longitude":89.810844,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326515,
-    "wof:geomhash":"e17f65f19a388f2908f29cf8cf5553bb",
+    "wof:geomhash":"80433e4e72039bf18aab293a059e1534",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108747515,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886217,
     "wof:name":"Nahi",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/751/9/1108747519.geojson
+++ b/data/110/874/751/9/1108747519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011557,
-    "geom:area_square_m":127251148.45354,
+    "geom:area_square_m":127250958.539198,
     "geom:bbox":"88.898899,26.986871,89.067883,27.142617",
     "geom:latitude":27.068028,
     "geom:longitude":88.984334,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.LH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326515,
-    "wof:geomhash":"e4622b3f7bbe92ddec6999fc16e0d8cb",
+    "wof:geomhash":"b38575bcf55240f13ae1e25767fda7b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747519,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886217,
     "wof:name":"Namgyel Chhoeling",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/753/1/1108747531.geojson
+++ b/data/110/874/753/1/1108747531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01954,
-    "geom:area_square_m":215479409.929193,
+    "geom:area_square_m":215479530.366884,
     "geom:bbox":"90.906871,26.78279,91.069559,27.009552",
     "geom:latitude":26.893392,
     "geom:longitude":90.987391,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326516,
-    "wof:geomhash":"c8948d2d69af17b2439fc4bb996ba3a1",
+    "wof:geomhash":"364467fa1e61fceddad690c82dc266e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747531,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886217,
     "wof:name":"Ngangla",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/753/3/1108747533.geojson
+++ b/data/110/874/753/3/1108747533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006569,
-    "geom:area_square_m":72162159.74614,
+    "geom:area_square_m":72162022.371376,
     "geom:bbox":"91.260008,27.275195,91.386422,27.38065",
     "geom:latitude":27.323013,
     "geom:longitude":91.318336,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326517,
-    "wof:geomhash":"52b55b461d6bb456871f4980556dc029",
+    "wof:geomhash":"ebb61f849a4d92f79b3bfcc13f427b65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747533,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886217,
     "wof:name":"Ngatshang",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/753/5/1108747535.geojson
+++ b/data/110/874/753/5/1108747535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012894,
-    "geom:area_square_m":142334695.289383,
+    "geom:area_square_m":142334829.794484,
     "geom:bbox":"89.857379,26.721991,90.053591,26.867304",
     "geom:latitude":26.779186,
     "geom:longitude":89.978481,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326517,
-    "wof:geomhash":"cfbf05d2ff747be486e5f94686203bb1",
+    "wof:geomhash":"184b02021d9dec2fb489be3ed45ad7a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747535,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886217,
     "wof:name":"Nichula",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/753/7/1108747537.geojson
+++ b/data/110/874/753/7/1108747537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016266,
-    "geom:area_square_m":179471651.027668,
+    "geom:area_square_m":179471528.085661,
     "geom:bbox":"91.002238,26.781255,91.270762,26.880632",
     "geom:latitude":26.837873,
     "geom:longitude":91.131332,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326517,
-    "wof:geomhash":"e14c5c492629dca4129b7a83b96d6641",
+    "wof:geomhash":"ac58f67ef72f56859b7cdee30f6173a6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747537,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Norbugang",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/754/3/1108747543.geojson
+++ b/data/110/874/754/3/1108747543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010807,
-    "geom:area_square_m":118469210.802281,
+    "geom:area_square_m":118469241.750135,
     "geom:bbox":"89.96413,27.501112,90.183139,27.63441",
     "geom:latitude":27.554792,
     "geom:longitude":90.079688,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326517,
-    "wof:geomhash":"e4871285b0ef04c8a832b807cbf1efe1",
+    "wof:geomhash":"8b3f87378aeefdd1dc8f3b67465ceb29",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747543,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Nyisho",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/754/5/1108747545.geojson
+++ b/data/110/874/754/5/1108747545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00903,
-    "geom:area_square_m":99625752.820828,
+    "geom:area_square_m":99625652.267247,
     "geom:bbox":"89.101253,26.811258,89.276652,26.891986",
     "geom:latitude":26.847032,
     "geom:longitude":89.191752,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.PG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326518,
-    "wof:geomhash":"1afb4b46208ecf8194c2223173b48cf1",
+    "wof:geomhash":"d4613bfe7d6766ee75b5ffe52ce807cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747545,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Pagli",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/754/7/1108747547.geojson
+++ b/data/110/874/754/7/1108747547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048726,
-    "geom:area_square_m":537388622.754277,
+    "geom:area_square_m":537388887.463621,
     "geom:bbox":"90.623337,26.775216,90.961292,27.021812",
     "geom:latitude":26.885112,
     "geom:longitude":90.791846,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.PK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326518,
-    "wof:geomhash":"54d2aa954d6069403371f1a7c82eaed4",
+    "wof:geomhash":"a30d9cff78434a11cee9a559d3b9eb8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747547,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Pangkhar",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/754/9/1108747549.geojson
+++ b/data/110/874/754/9/1108747549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012483,
-    "geom:area_square_m":137368449.467476,
+    "geom:area_square_m":137368417.163517,
     "geom:bbox":"90.064968,27.081897,90.248269,27.190965",
     "geom:latitude":27.136021,
     "geom:longitude":90.137756,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326518,
-    "wof:geomhash":"c98a79000720c5696b5a58398f46f078",
+    "wof:geomhash":"2e665805df4a971ea6472088751a69b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747549,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Patakla",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/755/5/1108747555.geojson
+++ b/data/110/874/755/5/1108747555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013881,
-    "geom:area_square_m":152354787.357108,
+    "geom:area_square_m":152354656.710742,
     "geom:bbox":"90.16248,27.343029,90.304577,27.511741",
     "geom:latitude":27.421515,
     "geom:longitude":90.230674,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.PJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326519,
-    "wof:geomhash":"9abe4f94430cbc990b013a972832f08b",
+    "wof:geomhash":"4511059f71ccf0413f2d751eeb67bc30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747555,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phobji",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/755/9/1108747559.geojson
+++ b/data/110/874/755/9/1108747559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009028,
-    "geom:area_square_m":99100620.46702,
+    "geom:area_square_m":99100624.970105,
     "geom:bbox":"91.684816,27.342843,91.823644,27.475577",
     "geom:latitude":27.410456,
     "geom:longitude":91.747958,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326519,
-    "wof:geomhash":"ee8888c89714494d0992b7f84f2cf8b5",
+    "wof:geomhash":"902efd38ab852baf1085912819829f68",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747559,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phongme",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/763/3/1108747633.geojson
+++ b/data/110/874/763/3/1108747633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002344,
-    "geom:area_square_m":25692470.572627,
+    "geom:area_square_m":25692506.414005,
     "geom:bbox":"89.794231,27.525723,89.857382,27.585024",
     "geom:latitude":27.559149,
     "geom:longitude":89.830516,
@@ -153,9 +153,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326527,
-    "wof:geomhash":"e63f70052625c149eb8dd921c8306ac9",
+    "wof:geomhash":"c50d8972b88e861c06163ef547b61c1f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108747633,
-    "wof:lastmodified":1636495664,
+    "wof:lastmodified":1695886660,
     "wof:name":"Talo",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/763/5/1108747635.geojson
+++ b/data/110/874/763/5/1108747635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047656,
-    "geom:area_square_m":521922379.068793,
+    "geom:area_square_m":521922379.068568,
     "geom:bbox":"90.7788980609,27.5109268287,91.0085756161,27.8495282798",
     "geom:latitude":27.662188,
     "geom:longitude":90.88084,
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"BT.BU.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326527,
-    "wof:geomhash":"34693bff01042a842b3a5fc13344d927",
+    "wof:geomhash":"fe8bafe84c9d08259c57fa2131129a57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108747635,
-    "wof:lastmodified":1566629988,
+    "wof:lastmodified":1695886271,
     "wof:name":"Tang",
     "wof:parent_id":85669537,
     "wof:placetype":"county",

--- a/data/110/874/763/9/1108747639.geojson
+++ b/data/110/874/763/9/1108747639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011967,
-    "geom:area_square_m":131661008.552311,
+    "geom:area_square_m":131661108.610148,
     "geom:bbox":"88.853502,27.083828,88.992479,27.237382",
     "geom:latitude":27.15926,
     "geom:longitude":88.927007,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326528,
-    "wof:geomhash":"55d273666236d144d4f4bca7acfb62e2",
+    "wof:geomhash":"fdd1ed1b2e1d2c10b41f3ccf1533326c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108747639,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Tendu",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/764/1/1108747641.geojson
+++ b/data/110/874/764/1/1108747641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006198,
-    "geom:area_square_m":68165739.369417,
+    "geom:area_square_m":68165815.065699,
     "geom:bbox":"91.285987,27.153741,91.391541,27.255106",
     "geom:latitude":27.201583,
     "geom:longitude":91.336788,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326528,
-    "wof:geomhash":"3515bdf42f9629a3dee4d0186c8f93af",
+    "wof:geomhash":"6376475d365cb433a66dd9625215bb86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747641,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Thangrong",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/764/5/1108747645.geojson
+++ b/data/110/874/764/5/1108747645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004806,
-    "geom:area_square_m":52909160.446812,
+    "geom:area_square_m":52909064.258765,
     "geom:bbox":"91.527698,27.024999,91.664796,27.175999",
     "geom:latitude":27.090277,
     "geom:longitude":91.595501,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326528,
-    "wof:geomhash":"43b57cb392d7ba3ed8778a662c6565f8",
+    "wof:geomhash":"72c3d71a47ea7c2a816d75137fe43990",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108747645,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Thrimshing",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/764/9/1108747649.geojson
+++ b/data/110/874/764/9/1108747649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009467,
-    "geom:area_square_m":103807909.062744,
+    "geom:area_square_m":103807788.714967,
     "geom:bbox":"89.705059,27.467102,89.849252,27.581178",
     "geom:latitude":27.522649,
     "geom:longitude":89.776591,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326528,
-    "wof:geomhash":"940a89831e43d582ea50e53e777cfeef",
+    "wof:geomhash":"00545be5f0f43a9a430f4f85506aeaff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747649,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Toepisa",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/765/1/1108747651.geojson
+++ b/data/110/874/765/1/1108747651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004506,
-    "geom:area_square_m":49416848.605519,
+    "geom:area_square_m":49416959.058501,
     "geom:bbox":"91.559206,27.46455,91.651475,27.546055",
     "geom:latitude":27.502322,
     "geom:longitude":91.602152,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326529,
-    "wof:geomhash":"db5675379a8794b02bdfee5a74f41fea",
+    "wof:geomhash":"dd0b40d7637d9bb2b73c9192a34c3f1b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747651,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Toetsho",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/765/5/1108747655.geojson
+++ b/data/110/874/765/5/1108747655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005901,
-    "geom:area_square_m":64746171.834427,
+    "geom:area_square_m":64746234.322757,
     "geom:bbox":"91.434791,27.41003,91.571611,27.493537",
     "geom:latitude":27.456734,
     "geom:longitude":91.502308,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.TZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326529,
-    "wof:geomhash":"7646612ded95009976c65d5e85f8ca7c",
+    "wof:geomhash":"b84100ccb48e26d5a8f4236056311ba9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747655,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Tomzhangtshen",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/765/7/1108747657.geojson
+++ b/data/110/874/765/7/1108747657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003615,
-    "geom:area_square_m":39864039.463315,
+    "geom:area_square_m":39863952.955746,
     "geom:bbox":"89.964909,26.866259,90.041847,26.953112",
     "geom:latitude":26.913585,
     "geom:longitude":89.999464,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326529,
-    "wof:geomhash":"16aa8203d4a11c2b7aaa39ba4488b61f",
+    "wof:geomhash":"8f1642f0f85287a5f810f253701ada73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747657,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Trashiding",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/765/9/1108747659.geojson
+++ b/data/110/874/765/9/1108747659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025101,
-    "geom:area_square_m":275141073.987446,
+    "geom:area_square_m":275141064.341378,
     "geom:bbox":"91.336141,27.47632,91.592741,27.647949",
     "geom:latitude":27.56636,
     "geom:longitude":91.470164,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.YG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326530,
-    "wof:geomhash":"2e37d1b665b3fbe183425aa9a4cd01af",
+    "wof:geomhash":"0b64a4074644161dc2fd5335521f65f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108747659,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Trashiyangtse",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/766/1/1108747661.geojson
+++ b/data/110/874/766/1/1108747661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032797,
-    "geom:area_square_m":360964637.489778,
+    "geom:area_square_m":360964657.258606,
     "geom:bbox":"90.52974,26.990742,90.838911,27.327756",
     "geom:latitude":27.116305,
     "geom:longitude":90.685982,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326530,
-    "wof:geomhash":"a91f38f41d505f67bb4d33d40fd8d401",
+    "wof:geomhash":"021ddaba4401b408c6452a4c6b883b81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747661,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Trong",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/766/3/1108747663.geojson
+++ b/data/110/874/766/3/1108747663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008048,
-    "geom:area_square_m":88369688.748691,
+    "geom:area_square_m":88369900.171291,
     "geom:bbox":"91.192371,27.321119,91.301619,27.438557",
     "geom:latitude":27.381043,
     "geom:longitude":91.246713,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326531,
-    "wof:geomhash":"6e63425b297d74fff0fec61785cb6718",
+    "wof:geomhash":"f113183e6d5343e5ee4605f2e4abc079",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747663,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Tsakaling",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/766/7/1108747667.geojson
+++ b/data/110/874/766/7/1108747667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013185,
-    "geom:area_square_m":144777500.368158,
+    "geom:area_square_m":144777520.108638,
     "geom:bbox":"91.049084,27.291446,91.211654,27.443608",
     "geom:latitude":27.376677,
     "geom:longitude":91.144666,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326531,
-    "wof:geomhash":"cadfa92139cdd8cc2d8847c3928471e8",
+    "wof:geomhash":"3911d33d57b757c91641a0c2b4726e40",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747667,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Tsamang",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/767/9/1108747679.geojson
+++ b/data/110/874/767/9/1108747679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001179,
-    "geom:area_square_m":12986740.247449,
+    "geom:area_square_m":12986770.148437,
     "geom:bbox":"90.070853,26.995669,90.119074,27.033725",
     "geom:latitude":27.014779,
     "geom:longitude":90.092666,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326533,
-    "wof:geomhash":"e7fdc9e6491467c6d6a3400b60dd740c",
+    "wof:geomhash":"e1afbb9e1fe7b276d97a4fe6e1de4f7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747679,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886224,
     "wof:name":"Tsholingkhor",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/768/1/1108747681.geojson
+++ b/data/110/874/768/1/1108747681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002861,
-    "geom:area_square_m":31502285.411017,
+    "geom:area_square_m":31502326.158572,
     "geom:bbox":"90.066344,27.029273,90.14071,27.085777",
     "geom:latitude":27.060223,
     "geom:longitude":90.102191,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326533,
-    "wof:geomhash":"457314d7dd0cf66fdc0cb91f7485d755",
+    "wof:geomhash":"61ba77ae7d5277298fe0a292cd218573",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747681,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Tsirangtoe",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/768/5/1108747685.geojson
+++ b/data/110/874/768/5/1108747685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009078,
-    "geom:area_square_m":99818608.201288,
+    "geom:area_square_m":99818484.541128,
     "geom:bbox":"91.375384,27.164942,91.517806,27.288252",
     "geom:latitude":27.224074,
     "geom:longitude":91.439309,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.UZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326533,
-    "wof:geomhash":"97c4690d63b0f2456ea01fbe5201a166",
+    "wof:geomhash":"cfd1827cdf9f3538c97367f7485eec65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747685,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Udzorong",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/768/7/1108747687.geojson
+++ b/data/110/874/768/7/1108747687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006082,
-    "geom:area_square_m":66805029.968246,
+    "geom:area_square_m":66805134.889814,
     "geom:bbox":"89.255664,27.303968,89.385598,27.385344",
     "geom:latitude":27.343509,
     "geom:longitude":89.320992,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.HA.EU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326533,
-    "wof:geomhash":"4a293d50a1aaa44a098ff7642c5ebc5f",
+    "wof:geomhash":"7c3100d4587d5c6f3760b45271645dc1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747687,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Uesu",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/110/874/768/9/1108747689.geojson
+++ b/data/110/874/768/9/1108747689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001704,
-    "geom:area_square_m":18783352.511859,
+    "geom:area_square_m":18783354.640382,
     "geom:bbox":"88.984422,26.919713,89.025532,26.995299",
     "geom:latitude":26.956704,
     "geom:longitude":89.00524,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326534,
-    "wof:geomhash":"06da5149b83289a7879bbe6727f0d641",
+    "wof:geomhash":"ac43ec6727b073de8da311b6827a06fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747689,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Ugentse",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/769/1/1108747691.geojson
+++ b/data/110/874/769/1/1108747691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011179,
-    "geom:area_square_m":123266457.60249,
+    "geom:area_square_m":123266373.637894,
     "geom:bbox":"90.515823,26.819795,90.694111,26.993591",
     "geom:latitude":26.901974,
     "geom:longitude":90.613574,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.UM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326534,
-    "wof:geomhash":"b24f8b916830702d8c8a4c8ade9c60b8",
+    "wof:geomhash":"35883ded96a9f4c9df5a2897cdf7e635",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747691,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Umling",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/769/3/1108747693.geojson
+++ b/data/110/874/769/3/1108747693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024238,
-    "geom:area_square_m":265923362.033412,
+    "geom:area_square_m":265923362.033403,
     "geom:bbox":"90.8046377715,27.3583784487,91.0126410512,27.5535713001",
     "geom:latitude":27.465531,
     "geom:longitude":90.915889,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"BT.BU.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326534,
-    "wof:geomhash":"75ee39b74503661e1d68f2345a2ce848",
+    "wof:geomhash":"c6e806382bf8de1035134a2cf54591ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108747693,
-    "wof:lastmodified":1566630018,
+    "wof:lastmodified":1695886271,
     "wof:name":"Ura",
     "wof:parent_id":85669537,
     "wof:placetype":"county",

--- a/data/110/874/769/5/1108747695.geojson
+++ b/data/110/874/769/5/1108747695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001842,
-    "geom:area_square_m":20215902.813943,
+    "geom:area_square_m":20215969.843094,
     "geom:bbox":"89.387058,27.383308,89.466202,27.439876",
     "geom:latitude":27.410247,
     "geom:longitude":89.424383,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.WC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326535,
-    "wof:geomhash":"744c53eacf72cbcfb4e614cb2b0e2408",
+    "wof:geomhash":"3fb55e94e137ab8121c32893fb6c7a0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747695,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Wangchang",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/769/7/1108747697.geojson
+++ b/data/110/874/769/7/1108747697.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108747697,
-    "wof:lastmodified":1694492893,
+    "wof:lastmodified":1695886420,
     "wof:name":"Wangphu",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/769/9/1108747699.geojson
+++ b/data/110/874/769/9/1108747699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008144,
-    "geom:area_square_m":89362074.342991,
+    "geom:area_square_m":89362125.244055,
     "geom:bbox":"91.584525,27.417666,91.767733,27.505568",
     "geom:latitude":27.457254,
     "geom:longitude":91.668338,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.YL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326535,
-    "wof:geomhash":"ceec92261df1cfc7fdcf3f6cb79efa24",
+    "wof:geomhash":"2c757cf940068c9816ece4b113f1bc0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108747699,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Yalang",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/770/3/1108747703.geojson
+++ b/data/110/874/770/3/1108747703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006793,
-    "geom:area_square_m":74598714.577915,
+    "geom:area_square_m":74598698.142176,
     "geom:bbox":"91.418525,27.311697,91.55835,27.41921",
     "geom:latitude":27.367064,
     "geom:longitude":91.493083,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.YN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326536,
-    "wof:geomhash":"bdb483fbca025de8008fb313c3cf4c82",
+    "wof:geomhash":"0f7f7723418e98cfb64c1e8a7b0616e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747703,
-    "wof:lastmodified":1627521907,
+    "wof:lastmodified":1695886227,
     "wof:name":"Yangnyer",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/770/5/1108747705.geojson
+++ b/data/110/874/770/5/1108747705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002074,
-    "geom:area_square_m":22858893.146111,
+    "geom:area_square_m":22858971.14012,
     "geom:bbox":"88.945066,26.918546,89.016172,27.009977",
     "geom:latitude":26.955195,
     "geom:longitude":88.979189,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.NN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326536,
-    "wof:geomhash":"244e2e1e78a2f21d22d6d74e231be717",
+    "wof:geomhash":"f1261ae738699b5147d69150101bcf3e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747705,
-    "wof:lastmodified":1627521907,
+    "wof:lastmodified":1695886227,
     "wof:name":"Yoeseltse",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/770/7/1108747707.geojson
+++ b/data/110/874/770/7/1108747707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002543,
-    "geom:area_square_m":28007268.195574,
+    "geom:area_square_m":28007351.088627,
     "geom:bbox":"91.315948,27.006487,91.37567,27.077383",
     "geom:latitude":27.040466,
     "geom:longitude":91.344227,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.YR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326536,
-    "wof:geomhash":"099c2142341181bcdf4bd7f76a6bf7ec",
+    "wof:geomhash":"77b64f5d7cd80f3df9e4d0c4223beda4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108747707,
-    "wof:lastmodified":1627521907,
+    "wof:lastmodified":1695886227,
     "wof:name":"Yurung",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/770/9/1108747709.geojson
+++ b/data/110/874/770/9/1108747709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006066,
-    "geom:area_square_m":66799307.931527,
+    "geom:area_square_m":66799307.93155,
     "geom:bbox":"91.3821836704,27.0150045056,91.511821946,27.1134604173",
     "geom:latitude":27.060527,
     "geom:longitude":91.448772,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.ZB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479326536,
-    "wof:geomhash":"412b413c1752347ca4ee973dfd05ce8d",
+    "wof:geomhash":"651dd4d7421e21f11474bd411f0f280c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108747709,
-    "wof:lastmodified":1566630013,
+    "wof:lastmodified":1695886271,
     "wof:name":"Zobel",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/812/1/1108748121.geojson
+++ b/data/110/874/812/1/1108748121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002526,
-    "geom:area_square_m":27750870.9139,
+    "geom:area_square_m":27750964.373684,
     "geom:bbox":"91.358449,27.307553,91.431198,27.388205",
     "geom:latitude":27.339568,
     "geom:longitude":91.399645,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328457,
-    "wof:geomhash":"ae9c3b473cd7c7dd39da7807a71a5dd7",
+    "wof:geomhash":"fe35a25fc5ebe81007f74943200c8012",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108748121,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886207,
     "wof:name":"Balam",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/812/3/1108748123.geojson
+++ b/data/110/874/812/3/1108748123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002189,
-    "geom:area_square_m":24012417.881761,
+    "geom:area_square_m":24012413.863014,
     "geom:bbox":"89.816974,27.476642,89.890568,27.53015",
     "geom:latitude":27.501833,
     "geom:longitude":89.857776,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328457,
-    "wof:geomhash":"1c5d62ee5d39d6d4d2d097528cfc5cb1",
+    "wof:geomhash":"293d7e8a2030779d1ab8e877911325ec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748123,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886207,
     "wof:name":"Bapisa",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/812/5/1108748125.geojson
+++ b/data/110/874/812/5/1108748125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017316,
-    "geom:area_square_m":190439692.123972,
+    "geom:area_square_m":190439692.124194,
     "geom:bbox":"88.746474,27.108077,88.9599993035,27.2756610281",
     "geom:latitude":27.201718,
     "geom:longitude":88.852663,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328457,
-    "wof:geomhash":"7232a519b8394bf2f711a14048b2cb87",
+    "wof:geomhash":"27d570307dc07da657ebd6d26bef3930",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1108748125,
-    "wof:lastmodified":1566630029,
+    "wof:lastmodified":1695886272,
     "wof:name":"Bara",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/812/7/1108748127.geojson
+++ b/data/110/874/812/7/1108748127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01918,
-    "geom:area_square_m":211126553.771766,
+    "geom:area_square_m":211126553.771873,
     "geom:bbox":"90.8350760863,26.9816497937,91.0351417464,27.2224394463",
     "geom:latitude":27.097179,
     "geom:longitude":90.964065,
@@ -110,9 +110,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328458,
-    "wof:geomhash":"c3abecce6b9a83d70acc2e59706f159d",
+    "wof:geomhash":"a1e0bb1a3ddf5d51c2ef31718b410376",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108748127,
-    "wof:lastmodified":1566630029,
+    "wof:lastmodified":1695886272,
     "wof:name":"Bardo",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/812/9/1108748129.geojson
+++ b/data/110/874/812/9/1108748129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003238,
-    "geom:area_square_m":35553875.871,
+    "geom:area_square_m":35553914.177207,
     "geom:bbox":"91.552797,27.346924,91.628964,27.419165",
     "geom:latitude":27.376648,
     "geom:longitude":91.595672,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328458,
-    "wof:geomhash":"e953cc0b7f8cc64753991e6c53616706",
+    "wof:geomhash":"9370d0a1777cb7c108f5d808892de0c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748129,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886207,
     "wof:name":"Bartsham",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/813/9/1108748139.geojson
+++ b/data/110/874/813/9/1108748139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004199,
-    "geom:area_square_m":46100699.20916,
+    "geom:area_square_m":46100700.948478,
     "geom:bbox":"91.617715,27.347997,91.694056,27.436093",
     "geom:latitude":27.390819,
     "geom:longitude":91.655526,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328459,
-    "wof:geomhash":"625d7ea01bca5d6f57bf59f94d160d8c",
+    "wof:geomhash":"3bfdabf7f621ea6a7bbc3c4f697b5814",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748139,
-    "wof:lastmodified":1627521893,
+    "wof:lastmodified":1695886207,
     "wof:name":"Bidung",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/819/1/1108748191.geojson
+++ b/data/110/874/819/1/1108748191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010255,
-    "geom:area_square_m":113039061.199065,
+    "geom:area_square_m":113039004.346343,
     "geom:bbox":"90.296816,26.85829,90.41752,27.012768",
     "geom:latitude":26.940761,
     "geom:longitude":90.353496,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328465,
-    "wof:geomhash":"40f3c893fcfb86533a4c64489fada516",
+    "wof:geomhash":"8d259f9a2c5801ad3b712353bb21b49b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748191,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Dekiling",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/819/3/1108748193.geojson
+++ b/data/110/874/819/3/1108748193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00947,
-    "geom:area_square_m":104306351.312901,
+    "geom:area_square_m":104306491.599505,
     "geom:bbox":"89.214725,26.964312,89.327953,27.08671",
     "geom:latitude":27.028678,
     "geom:longitude":89.273914,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.DC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328465,
-    "wof:geomhash":"6a0316cc0ec86646bf243a6aebc1c563",
+    "wof:geomhash":"6ba0d50f3f059f6ad5a2b10e69b222d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748193,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Denchhukha",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/819/5/1108748195.geojson
+++ b/data/110/874/819/5/1108748195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008247,
-    "geom:area_square_m":91034976.322133,
+    "geom:area_square_m":91035093.34485,
     "geom:bbox":"89.812167,26.73728,89.946143,26.842127",
     "geom:latitude":26.788843,
     "geom:longitude":89.874254,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328465,
-    "wof:geomhash":"eb5de4b4c5be72b31f3b8d4410aad6a2",
+    "wof:geomhash":"50d01bc55ca8044a17085eaf41e3786c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108748195,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Deorali",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/874/819/7/1108748197.geojson
+++ b/data/110/874/819/7/1108748197.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108748197,
-    "wof:lastmodified":1694492841,
+    "wof:lastmodified":1695886284,
     "wof:name":"Dewathang",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/819/9/1108748199.geojson
+++ b/data/110/874/819/9/1108748199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020182,
-    "geom:area_square_m":222247720.868954,
+    "geom:area_square_m":222247914.336961,
     "geom:bbox":"90.243098,26.961924,90.474435,27.150403",
     "geom:latitude":27.054825,
     "geom:longitude":90.343303,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.DV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328466,
-    "wof:geomhash":"7c6cb6099957b1d0be58cce82b064954",
+    "wof:geomhash":"8a289285a1c1e25d157e2011612d623f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748199,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Doban",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/821/1/1108748211.geojson
+++ b/data/110/874/821/1/1108748211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017812,
-    "geom:area_square_m":195269537.635515,
+    "geom:area_square_m":195269476.049919,
     "geom:bbox":"89.360177,27.462547,89.504449,27.652252",
     "geom:latitude":27.553806,
     "geom:longitude":89.429088,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.DT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328467,
-    "wof:geomhash":"236bab9dffed383d3a74e7421cd169d9",
+    "wof:geomhash":"477d808df1ad85d1f1a0bdc0293ab72a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748211,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886209,
     "wof:name":"Doteng",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/822/1/1108748221.geojson
+++ b/data/110/874/822/1/1108748221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004241,
-    "geom:area_square_m":46724944.803598,
+    "geom:area_square_m":46724929.913109,
     "geom:bbox":"90.153247,26.978437,90.247542,27.043497",
     "geom:latitude":27.009533,
     "geom:longitude":90.203119,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328468,
-    "wof:geomhash":"5eacb9547a28a19ee2dcc6be9f6f90f1",
+    "wof:geomhash":"d1327e364cf6ac6eb2ceee45d2ba34dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748221,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Dunglegang",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/822/5/1108748225.geojson
+++ b/data/110/874/822/5/1108748225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010011,
-    "geom:area_square_m":110325554.643023,
+    "geom:area_square_m":110325428.341888,
     "geom:bbox":"91.182567,26.923443,91.364215,27.036084",
     "geom:latitude":26.974461,
     "geom:longitude":91.275981,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328469,
-    "wof:geomhash":"64a88fee69d1ecfe7b4e4e59b791526e",
+    "wof:geomhash":"289088fdb4dcc6e4b00c1b0693e1c52e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748225,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Dungmin",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/822/7/1108748227.geojson
+++ b/data/110/874/822/7/1108748227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018382,
-    "geom:area_square_m":202348150.30263,
+    "geom:area_square_m":202348044.940267,
     "geom:bbox":"89.265706,26.93568,89.466808,27.225888",
     "geom:latitude":27.095273,
     "geom:longitude":89.368217,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.DU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328469,
-    "wof:geomhash":"c7ce58f8b00fcdbb94123fbf2f8b5fbc",
+    "wof:geomhash":"dc32576c662d411b190ee520c38329e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748227,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Dungna",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/822/9/1108748229.geojson
+++ b/data/110/874/822/9/1108748229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004396,
-    "geom:area_square_m":48415944.295677,
+    "geom:area_square_m":48415939.682499,
     "geom:bbox":"89.110785,27.0058,89.215059,27.08664",
     "geom:latitude":27.035535,
     "geom:longitude":89.16356,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.DT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328469,
-    "wof:geomhash":"fadff662cfd0f69cfb38a825ae01dfb5",
+    "wof:geomhash":"6a99a2c7b606e5df939304a7cf0fd7fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748229,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Dungtoe",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/823/3/1108748233.geojson
+++ b/data/110/874/823/3/1108748233.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108748233,
-    "wof:lastmodified":1694492845,
+    "wof:lastmodified":1695886292,
     "wof:name":"Gakiling",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/110/874/823/5/1108748235.geojson
+++ b/data/110/874/823/5/1108748235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002667,
-    "geom:area_square_m":29275013.728097,
+    "geom:area_square_m":29274988.578271,
     "geom:bbox":"89.824775,27.403746,89.908024,27.461957",
     "geom:latitude":27.431356,
     "geom:longitude":89.878113,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328470,
-    "wof:geomhash":"0ff57890715c31a14341faa065e68e6f",
+    "wof:geomhash":"8d2fbe68fc15b85b852fd98e6d8692fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748235,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Gasetsho Gom",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/823/7/1108748237.geojson
+++ b/data/110/874/823/7/1108748237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019008,
-    "geom:area_square_m":208754267.58503,
+    "geom:area_square_m":208754320.721624,
     "geom:bbox":"89.709221,27.269281,89.916367,27.420479",
     "geom:latitude":27.355755,
     "geom:longitude":89.806909,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328470,
-    "wof:geomhash":"a436962bbc91082e37efdcee78bf9aac",
+    "wof:geomhash":"0189cea6cfba4aca937d9f291b86a634",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748237,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886210,
     "wof:name":"Gasetsho Om",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/823/9/1108748239.geojson
+++ b/data/110/874/823/9/1108748239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004961,
-    "geom:area_square_m":54695716.382848,
+    "geom:area_square_m":54695716.382831,
     "geom:bbox":"90.4410729619,26.8478817608,90.5150471956,26.9771242874",
     "geom:latitude":26.920551,
     "geom:longitude":90.484571,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328470,
-    "wof:geomhash":"00dc2c882a8b2fc82e7dd1de42cda5cf",
+    "wof:geomhash":"a63908efa7d432c3f4f47a82b06392c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108748239,
-    "wof:lastmodified":1566630027,
+    "wof:lastmodified":1695886271,
     "wof:name":"Gelephu",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/824/3/1108748243.geojson
+++ b/data/110/874/824/3/1108748243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020137,
-    "geom:area_square_m":221826268.773789,
+    "geom:area_square_m":221826267.990772,
     "geom:bbox":"89.410654,26.857447,89.53977,27.193093",
     "geom:latitude":27.018402,
     "geom:longitude":89.489742,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328470,
-    "wof:geomhash":"af7dc309cb104043a721e3ff7f0e1234",
+    "wof:geomhash":"adc0e68d436f2d515bf84a2116467f74",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748243,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886211,
     "wof:name":"Geling",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/824/5/1108748245.geojson
+++ b/data/110/874/824/5/1108748245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005553,
-    "geom:area_square_m":61007321.51994,
+    "geom:area_square_m":61007285.031172,
     "geom:bbox":"89.551596,27.259917,89.685967,27.352523",
     "geom:latitude":27.308014,
     "geom:longitude":89.611348,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328471,
-    "wof:geomhash":"b52bc3bae5b18ce0dcd21a29ec432bd2",
+    "wof:geomhash":"6a93534eeff41fcf450cf55945585e02",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748245,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886212,
     "wof:name":"Genye",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/824/7/1108748247.geojson
+++ b/data/110/874/824/7/1108748247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003473,
-    "geom:area_square_m":38295411.887538,
+    "geom:area_square_m":38295398.815182,
     "geom:bbox":"89.841072,26.885026,89.932446,26.956573",
     "geom:latitude":26.919128,
     "geom:longitude":89.892078,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328471,
-    "wof:geomhash":"e43dfa26c3306f2882f137a9699fdd84",
+    "wof:geomhash":"d70de85d440f29c3acb84bce75ca93d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748247,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886212,
     "wof:name":"Gesarling",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/826/9/1108748269.geojson
+++ b/data/110/874/826/9/1108748269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003399,
-    "geom:area_square_m":37256287.863402,
+    "geom:area_square_m":37256178.145115,
     "geom:bbox":"89.780598,27.525822,89.877541,27.626858",
     "geom:latitude":27.582912,
     "geom:longitude":89.833309,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328473,
-    "wof:geomhash":"759cc52cb718f2a058f6792613aaae68",
+    "wof:geomhash":"36b75bfc3810a1be927aa9faebf3cd0d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748269,
-    "wof:lastmodified":1627521897,
+    "wof:lastmodified":1695886212,
     "wof:name":"Guma",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/828/1/1108748281.geojson
+++ b/data/110/874/828/1/1108748281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012618,
-    "geom:area_square_m":138461418.422801,
+    "geom:area_square_m":138461379.351041,
     "geom:bbox":"90.977929,27.390567,91.182398,27.517369",
     "geom:latitude":27.451264,
     "geom:longitude":91.078554,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.JR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328474,
-    "wof:geomhash":"b41493c760f56aa9b1ce2444d77433d7",
+    "wof:geomhash":"2d1348ca95412c1874a8f48e947dc331",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748281,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Jaray",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/828/3/1108748283.geojson
+++ b/data/110/874/828/3/1108748283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045542,
-    "geom:area_square_m":501444826.1233,
+    "geom:area_square_m":501444816.525773,
     "geom:bbox":"90.324517,26.948102,90.694079,27.221355",
     "geom:latitude":27.069269,
     "geom:longitude":90.504814,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328475,
-    "wof:geomhash":"313d600bd142fc0401b9e1e48ec22e76",
+    "wof:geomhash":"3a68158b1374680b782f82e62ef244e1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748283,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Jigmichhoeling",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/828/5/1108748285.geojson
+++ b/data/110/874/828/5/1108748285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005144,
-    "geom:area_square_m":56628037.215971,
+    "geom:area_square_m":56628153.89312,
     "geom:bbox":"91.203625,27.049234,91.297189,27.139915",
     "geom:latitude":27.088721,
     "geom:longitude":91.248524,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.JM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328475,
-    "wof:geomhash":"0c64b08a5db6d9f48ba6b1e5cae442d1",
+    "wof:geomhash":"9d95f850c826e771277766ed25d31e49",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748285,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Jurmey",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/828/7/1108748287.geojson
+++ b/data/110/874/828/7/1108748287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018813,
-    "geom:area_square_m":206076224.030565,
+    "geom:area_square_m":206076341.407802,
     "geom:bbox":"89.632702,27.546761,89.82394,27.738236",
     "geom:latitude":27.641972,
     "geom:longitude":89.716646,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328475,
-    "wof:geomhash":"1a21972811f677e4606b37757e8204cb",
+    "wof:geomhash":"c52fb0c684822020ed90ad9c7e3822fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748287,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Kabjisa",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/828/9/1108748289.geojson
+++ b/data/110/874/828/9/1108748289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017339,
-    "geom:area_square_m":191026032.825621,
+    "geom:area_square_m":191026026.500693,
     "geom:bbox":"89.753308,26.936,89.948635,27.068503",
     "geom:latitude":27.001375,
     "geom:longitude":89.852996,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328475,
-    "wof:geomhash":"1dbe1aa9881e7d472a6bb55869d920e5",
+    "wof:geomhash":"cf473831ee8c23d3c60f4a78d56e05fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748289,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Kalidzingkha",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/829/1/1108748291.geojson
+++ b/data/110/874/829/1/1108748291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006161,
-    "geom:area_square_m":67717988.214628,
+    "geom:area_square_m":67717988.214594,
     "geom:bbox":"91.4632263478,27.2372272033,91.6064200073,27.3217180427",
     "geom:latitude":27.272903,
     "geom:longitude":91.529907,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328476,
-    "wof:geomhash":"9ba21a261cb7d40838b5fa123c59534e",
+    "wof:geomhash":"67cc36837b699b228cb650baf6922eaf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108748291,
-    "wof:lastmodified":1566629997,
+    "wof:lastmodified":1695886271,
     "wof:name":"Kanglung",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/829/3/1108748293.geojson
+++ b/data/110/874/829/3/1108748293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031388,
-    "geom:area_square_m":345319784.41421,
+    "geom:area_square_m":345319872.637927,
     "geom:bbox":"91.600152,27.046947,91.825624,27.277667",
     "geom:latitude":27.160032,
     "geom:longitude":91.720211,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328476,
-    "wof:geomhash":"72a1184f178c408b56b5cfc1c2c99b36",
+    "wof:geomhash":"17c8e8a98bf5873755d2ece436a6f1cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748293,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886213,
     "wof:name":"Kangpara",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/829/7/1108748297.geojson
+++ b/data/110/874/829/7/1108748297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057431,
-    "geom:area_square_m":628435719.481409,
+    "geom:area_square_m":628435669.32384,
     "geom:bbox":"89.958507,27.538925,90.244168,27.983959",
     "geom:latitude":27.755364,
     "geom:longitude":90.120643,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.KZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328477,
-    "wof:geomhash":"948756cef373289151097c391bb6686c",
+    "wof:geomhash":"2957cc314dd0deda686594f01a10866e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748297,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886214,
     "wof:name":"Kazhi",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/829/9/1108748299.geojson
+++ b/data/110/874/829/9/1108748299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008925,
-    "geom:area_square_m":98211104.513896,
+    "geom:area_square_m":98211118.317797,
     "geom:bbox":"91.233705,27.068912,91.364113,27.190094",
     "geom:latitude":27.133441,
     "geom:longitude":91.30163,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328477,
-    "wof:geomhash":"7600858ec298e779948d33cfb6c3c69f",
+    "wof:geomhash":"6cc88bae777b777c22b74e066a1bcbd4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108748299,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886214,
     "wof:name":"Kengkhar",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/831/1/1108748311.geojson
+++ b/data/110/874/831/1/1108748311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001611,
-    "geom:area_square_m":17747739.033763,
+    "geom:area_square_m":17747746.305871,
     "geom:bbox":"90.110576,26.975916,90.160013,27.027048",
     "geom:latitude":27.002466,
     "geom:longitude":90.137955,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328478,
-    "wof:geomhash":"0cb23a4f494bca7fb9dee00f98c0693b",
+    "wof:geomhash":"e42c08b93ef71ac91efbc5006d12be73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748311,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Kikorthang",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/831/5/1108748315.geojson
+++ b/data/110/874/831/5/1108748315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026489,
-    "geom:area_square_m":291288343.125776,
+    "geom:area_square_m":291288443.091262,
     "geom:bbox":"90.352442,27.136251,90.6562,27.288509",
     "geom:latitude":27.214146,
     "geom:longitude":90.499349,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TO.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328479,
-    "wof:geomhash":"4aeb243db0471f92fd0566ff70f0457e",
+    "wof:geomhash":"6b65cc806661133713590fc0ab118592",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748315,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886208,
     "wof:name":"Korphu",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/110/874/831/7/1108748317.geojson
+++ b/data/110/874/831/7/1108748317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089139,
-    "geom:area_square_m":973901398.886354,
+    "geom:area_square_m":973901461.378096,
     "geom:bbox":"90.772701,27.780164,91.281204,28.065571",
     "geom:latitude":27.922843,
     "geom:longitude":91.033812,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328479,
-    "wof:geomhash":"8dab30552f291387507e1f9a298c240f",
+    "wof:geomhash":"cf5f563d5e55ce11426c3771091a4c3c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748317,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Kurtoe",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/831/9/1108748319.geojson
+++ b/data/110/874/831/9/1108748319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009968,
-    "geom:area_square_m":109723395.649186,
+    "geom:area_square_m":109723289.104429,
     "geom:bbox":"89.934571,27.039519,90.076062,27.150484",
     "geom:latitude":27.097724,
     "geom:longitude":90.004431,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.LJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328479,
-    "wof:geomhash":"fa14927130158dfaed1e9097e1aa8a90",
+    "wof:geomhash":"8a36c9b621f6ca2ea95e884e3a425230",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748319,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lajab",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/833/3/1108748333.geojson
+++ b/data/110/874/833/3/1108748333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003101,
-    "geom:area_square_m":33993295.031092,
+    "geom:area_square_m":33993305.773828,
     "geom:bbox":"89.870046,27.513766,89.958718,27.581223",
     "geom:latitude":27.547467,
     "geom:longitude":89.916433,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.LI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328480,
-    "wof:geomhash":"6520715c7de7389f4593bed6b0986aec",
+    "wof:geomhash":"5e23740e2c09bda12510df3241d23cfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748333,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lingmukha",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/833/5/1108748335.geojson
+++ b/data/110/874/833/5/1108748335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035366,
-    "geom:area_square_m":386645223.315998,
+    "geom:area_square_m":386645145.63531,
     "geom:bbox":"89.330135,27.677715,89.585265,27.996897",
     "geom:latitude":27.854128,
     "geom:longitude":89.457623,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.LZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328481,
-    "wof:geomhash":"5918fb91e419ae7c643a2095f16a970e",
+    "wof:geomhash":"54e47bdf6d20621374de4fc20ca4a209",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108748335,
-    "wof:lastmodified":1627521899,
+    "wof:lastmodified":1695886215,
     "wof:name":"Lingzhi",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/833/7/1108748337.geojson
+++ b/data/110/874/833/7/1108748337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006529,
-    "geom:area_square_m":71952958.407092,
+    "geom:area_square_m":71953045.466957,
     "geom:bbox":"89.309168,26.911636,89.427977,27.006748",
     "geom:latitude":26.964472,
     "geom:longitude":89.371509,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328481,
-    "wof:geomhash":"b5963a6dec57847fd40458f8485049be",
+    "wof:geomhash":"48d6b2d8c2ac39c3e06b50055a0cf832",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748337,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886217,
     "wof:name":"Logchina",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/833/9/1108748339.geojson
+++ b/data/110/874/833/9/1108748339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009626,
-    "geom:area_square_m":105929919.467308,
+    "geom:area_square_m":105929875.792041,
     "geom:bbox":"91.469267,27.063966,91.588059,27.187993",
     "geom:latitude":27.130881,
     "geom:longitude":91.529167,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328481,
-    "wof:geomhash":"fb1cdb5a791672b37f7deb224c5d37db",
+    "wof:geomhash":"f7c1f554666a418f1ec237ad34ddca25",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748339,
-    "wof:lastmodified":1627521900,
+    "wof:lastmodified":1695886217,
     "wof:name":"Lumang",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/837/1/1108748371.geojson
+++ b/data/110/874/837/1/1108748371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044681,
-    "geom:area_square_m":491379054.975061,
+    "geom:area_square_m":491379035.257639,
     "geom:bbox":"90.695696,27.017718,90.898495,27.388318",
     "geom:latitude":27.203596,
     "geom:longitude":90.802911,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328485,
-    "wof:geomhash":"790b2465ecd7f3bf285e2ca470b837af",
+    "wof:geomhash":"0ff2355653079d7d286cb4dc101bf4d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748371,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Nangkor",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/837/3/1108748373.geojson
+++ b/data/110/874/837/3/1108748373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007494,
-    "geom:area_square_m":82489638.445825,
+    "geom:area_square_m":82489600.190022,
     "geom:bbox":"91.413498,27.015458,91.548618,27.178167",
     "geom:latitude":27.103472,
     "geom:longitude":91.474042,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.NN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328485,
-    "wof:geomhash":"b628d5be252d98a7db9ea2aaca75d1f0",
+    "wof:geomhash":"69d69ef396425958d9e1a1e654138761",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748373,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Nanong",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/837/5/1108748375.geojson
+++ b/data/110/874/837/5/1108748375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004496,
-    "geom:area_square_m":49405912.860705,
+    "geom:area_square_m":49405958.603148,
     "geom:bbox":"91.378315,27.257673,91.484681,27.347312",
     "geom:latitude":27.301218,
     "geom:longitude":91.42764,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.CK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328486,
-    "wof:geomhash":"bfdc7f5cfd5100dbf8fb483396d1b813",
+    "wof:geomhash":"0e0b76681354b59e922787fcd271b626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748375,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886218,
     "wof:name":"Narang",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/837/7/1108748377.geojson
+++ b/data/110/874/837/7/1108748377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025783,
-    "geom:area_square_m":282304538.430182,
+    "geom:area_square_m":282304538.430312,
     "geom:bbox":"89.3967082199,27.5670275965,89.6570063185,27.7902823926",
     "geom:latitude":27.687175,
     "geom:longitude":89.52695,
@@ -176,9 +176,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328486,
-    "wof:geomhash":"aa1802553d3f7b42abf5c77fa4fce2d6",
+    "wof:geomhash":"ff410ffbacaa31aaeb0aba09854ff9b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1108748377,
-    "wof:lastmodified":1566630037,
+    "wof:lastmodified":1695886272,
     "wof:name":"Naro",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/839/7/1108748397.geojson
+++ b/data/110/874/839/7/1108748397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00681,
-    "geom:area_square_m":75104185.54097,
+    "geom:area_square_m":75104364.507694,
     "geom:bbox":"91.723819,26.831818,91.814443,26.946537",
     "geom:latitude":26.888413,
     "geom:longitude":91.767039,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.PM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328489,
-    "wof:geomhash":"8db9ad071eefcada0ddf084f789a5637",
+    "wof:geomhash":"37ef3ffcb64b2bb6837cc40cfea51369",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748397,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Pemathang",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/839/9/1108748399.geojson
+++ b/data/110/874/839/9/1108748399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002958,
-    "geom:area_square_m":32439917.867325,
+    "geom:area_square_m":32439856.548165,
     "geom:bbox":"89.910933,27.485068,89.989605,27.569379",
     "geom:latitude":27.526033,
     "geom:longitude":89.949777,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.PY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328489,
-    "wof:geomhash":"0acc137ccbc94abc7a36c50aadf40755",
+    "wof:geomhash":"2d2bfa9954acea8da7886cd721b1e55a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748399,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phangyuel",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/840/7/1108748407.geojson
+++ b/data/110/874/840/7/1108748407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012452,
-    "geom:area_square_m":137064900.70782,
+    "geom:area_square_m":137064965.437785,
     "geom:bbox":"90.129312,27.036939,90.345475,27.183154",
     "geom:latitude":27.099012,
     "geom:longitude":90.231127,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328489,
-    "wof:geomhash":"9099aad9ab44f593d5dcde08eab1898a",
+    "wof:geomhash":"57e3653be21d68068df1dbe66b6a0539",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748407,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phuentenchhu",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/840/9/1108748409.geojson
+++ b/data/110/874/840/9/1108748409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01216,
-    "geom:area_square_m":134072187.852602,
+    "geom:area_square_m":134072182.544656,
     "geom:bbox":"89.274819,26.83976,89.475069,26.996252",
     "geom:latitude":26.918596,
     "geom:longitude":89.394778,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.PG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328490,
-    "wof:geomhash":"3fe14ce32ce132432bc62862f663c25c",
+    "wof:geomhash":"8c53dc716c2d41d6c60bce9572c006b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748409,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phuentsholing",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/841/1/1108748411.geojson
+++ b/data/110/874/841/1/1108748411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011678,
-    "geom:area_square_m":128822220.350691,
+    "geom:area_square_m":128822169.8753,
     "geom:bbox":"91.597393,26.809059,91.759917,26.926018",
     "geom:latitude":26.859326,
     "geom:longitude":91.677987,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328490,
-    "wof:geomhash":"65bd846f1a934d3859fba59ab3c02863",
+    "wof:geomhash":"543ffe00f9a9111d32f1209ca467652f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748411,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Phuntsthothang",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/841/3/1108748413.geojson
+++ b/data/110/874/841/3/1108748413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002616,
-    "geom:area_square_m":28732806.102302,
+    "geom:area_square_m":28732806.102264,
     "geom:bbox":"91.6721885251,27.3270876651,91.7446130876,27.3877090003",
     "geom:latitude":27.357115,
     "geom:longitude":91.710579,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.RD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328490,
-    "wof:geomhash":"088187776af8ffb68f22c3f586163f7d",
+    "wof:geomhash":"2965283a7415b8186ee77630e42135af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108748413,
-    "wof:lastmodified":1566630025,
+    "wof:lastmodified":1695886271,
     "wof:name":"Radi",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/841/5/1108748415.geojson
+++ b/data/110/874/841/5/1108748415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002075,
-    "geom:area_square_m":22779685.217036,
+    "geom:area_square_m":22779676.087932,
     "geom:bbox":"91.550827,27.380633,91.612069,27.439924",
     "geom:latitude":27.409561,
     "geom:longitude":91.578756,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TY.RJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328490,
-    "wof:geomhash":"dee877e1073e19592717a20046860d79",
+    "wof:geomhash":"aaac5a4da1c5a5549058d053cff94a1e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748415,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886220,
     "wof:name":"Ramjar",
     "wof:parent_id":85669555,
     "wof:placetype":"county",

--- a/data/110/874/841/7/1108748417.geojson
+++ b/data/110/874/841/7/1108748417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002298,
-    "geom:area_square_m":25326272.258513,
+    "geom:area_square_m":25326207.258669,
     "geom:bbox":"90.066563,26.95944,90.141625,27.005726",
     "geom:latitude":26.980903,
     "geom:longitude":90.100123,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.RT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328491,
-    "wof:geomhash":"f378929e14095c40efc82ff194810465",
+    "wof:geomhash":"3093350813a0b3085cc867d615d34820",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748417,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886220,
     "wof:name":"Rangthangling",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/841/9/1108748419.geojson
+++ b/data/110/874/841/9/1108748419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014563,
-    "geom:area_square_m":159870260.520769,
+    "geom:area_square_m":159870100.276487,
     "geom:bbox":"89.897468,27.303914,90.032559,27.493725",
     "geom:latitude":27.401413,
     "geom:longitude":89.95493,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.WP.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328491,
-    "wof:geomhash":"be2ff7a3c5947401ddddc5b3cae1f490",
+    "wof:geomhash":"83a10b19362d835586b25b5c23df6b63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748419,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886220,
     "wof:name":"Ruepisa",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/110/874/842/3/1108748423.geojson
+++ b/data/110/874/842/3/1108748423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041541,
-    "geom:area_square_m":456091492.482471,
+    "geom:area_square_m":456091830.794829,
     "geom:bbox":"91.777171,27.274827,92.125127,27.486344",
     "geom:latitude":27.386027,
     "geom:longitude":91.931089,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328491,
-    "wof:geomhash":"8c0a2e1026b597f96aff17cab23a52f6",
+    "wof:geomhash":"c73f3a7c1b97a65eca6d844b5833e906",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748423,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886220,
     "wof:name":"Sakteng",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/842/5/1108748425.geojson
+++ b/data/110/874/842/5/1108748425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018262,
-    "geom:area_square_m":200663585.351193,
+    "geom:area_square_m":200663585.351287,
     "geom:bbox":"89.1515770436,27.2173137589,89.3666592003,27.3807169378",
     "geom:latitude":27.300152,
     "geom:longitude":89.252069,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"BT.HA.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328491,
-    "wof:geomhash":"06627273daa7b06f77aab3793af5a4bf",
+    "wof:geomhash":"40341ec41c38dc7ac778c301656151dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108748425,
-    "wof:lastmodified":1566630000,
+    "wof:lastmodified":1695886271,
     "wof:name":"Sama",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/110/874/842/7/1108748427.geojson
+++ b/data/110/874/842/7/1108748427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006792,
-    "geom:area_square_m":74930102.237661,
+    "geom:area_square_m":74930132.186364,
     "geom:bbox":"89.415296,26.802229,89.548141,26.897439",
     "geom:latitude":26.84215,
     "geom:longitude":89.485112,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CK.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328492,
-    "wof:geomhash":"15a1ec5e8d8527363921ad88da6997ff",
+    "wof:geomhash":"eaccfc794c03e102ffb2cce142f5cc6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748427,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886220,
     "wof:name":"Samphelling",
     "wof:parent_id":85669501,
     "wof:placetype":"county",

--- a/data/110/874/842/9/1108748429.geojson
+++ b/data/110/874/842/9/1108748429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004788,
-    "geom:area_square_m":52795539.778535,
+    "geom:area_square_m":52795586.718183,
     "geom:bbox":"91.789637,26.858803,91.882702,26.956323",
     "geom:latitude":26.91611,
     "geom:longitude":91.829091,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328492,
-    "wof:geomhash":"5ea786b4cd0d724dbe23b9363439f9a3",
+    "wof:geomhash":"d6f14dd54f50d71cf820fdb5aa20ce57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748429,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886220,
     "wof:name":"Samrang",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/843/1/1108748431.geojson
+++ b/data/110/874/843/1/1108748431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010545,
-    "geom:area_square_m":116266444.037655,
+    "geom:area_square_m":116266553.37112,
     "geom:bbox":"89.046764,26.853272,89.199432,26.988273",
     "geom:latitude":26.915734,
     "geom:longitude":89.126824,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328492,
-    "wof:geomhash":"994c98330889ab5b75d594b3b5a8b9f3",
+    "wof:geomhash":"61afd1a9fe8658ae5efae455479364d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108748431,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886220,
     "wof:name":"Samtse",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/843/3/1108748433.geojson
+++ b/data/110/874/843/3/1108748433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019481,
-    "geom:area_square_m":214982458.648492,
+    "geom:area_square_m":214982354.938108,
     "geom:bbox":"90.011657,26.729808,90.232886,26.936478",
     "geom:latitude":26.81553,
     "geom:longitude":90.131612,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328492,
-    "wof:geomhash":"350c29245d1a5460d5d72d37cbc849eb",
+    "wof:geomhash":"bd6e8fb5ba44e4e1cc6e07667f5ec174",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748433,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886220,
     "wof:name":"Senge",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/843/5/1108748435.geojson
+++ b/data/110/874/843/5/1108748435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027823,
-    "geom:area_square_m":306509484.311628,
+    "geom:area_square_m":306509475.7808,
     "geom:bbox":"91.802875,26.930829,92.10755,27.08172",
     "geom:latitude":27.010314,
     "geom:longitude":91.949501,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SJ.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328493,
-    "wof:geomhash":"9c92b957fce9ef8167c94177fce76293",
+    "wof:geomhash":"537592c3fa0bbb5920c39f79827af711",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748435,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Serthig",
     "wof:parent_id":85669579,
     "wof:placetype":"county",

--- a/data/110/874/843/7/1108748437.geojson
+++ b/data/110/874/843/7/1108748437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007298,
-    "geom:area_square_m":80149947.366802,
+    "geom:area_square_m":80149870.207134,
     "geom:bbox":"89.394193,27.299865,89.522478,27.419987",
     "geom:latitude":27.361152,
     "geom:longitude":89.466407,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328493,
-    "wof:geomhash":"56181091ccddadc27355cfeb1c54e156",
+    "wof:geomhash":"e9eab67e0302f9545a0e5e6796dbf5db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748437,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shapa",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/844/1/1108748441.geojson
+++ b/data/110/874/844/1/1108748441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001338,
-    "geom:area_square_m":14735656.420914,
+    "geom:area_square_m":14735637.736695,
     "geom:bbox":"90.136443,27.021324,90.199503,27.054141",
     "geom:latitude":27.037235,
     "geom:longitude":90.166281,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.CR.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328493,
-    "wof:geomhash":"8311480f1c9d9eb6815bdc1ac0f1dc1f",
+    "wof:geomhash":"807a6fbe2b59c41d417ba45a1b0f2b50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748441,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shemjong",
     "wof:parent_id":85669541,
     "wof:placetype":"county",

--- a/data/110/874/844/3/1108748443.geojson
+++ b/data/110/874/844/3/1108748443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005781,
-    "geom:area_square_m":63339816.795066,
+    "geom:area_square_m":63339838.047633,
     "geom:bbox":"89.897597,27.570502,90.022427,27.643371",
     "geom:latitude":27.608461,
     "geom:longitude":89.954257,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PN.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328493,
-    "wof:geomhash":"8170e6359d27db7f7e0073bb0db7029f",
+    "wof:geomhash":"c0715791e0e4de9a8f24eb8ce99c0818",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748443,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shengabjimi",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/110/874/844/5/1108748445.geojson
+++ b/data/110/874/844/5/1108748445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027519,
-    "geom:area_square_m":301957293.689096,
+    "geom:area_square_m":301957282.101511,
     "geom:bbox":"91.278408,27.32561,91.449026,27.600487",
     "geom:latitude":27.454347,
     "geom:longitude":91.357188,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328494,
-    "wof:geomhash":"820c9452949a9027df38bb07cbbf0bac",
+    "wof:geomhash":"96f9e4dee210dc4a6afbde36c6eaae04",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748445,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shermung",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/844/7/1108748447.geojson
+++ b/data/110/874/844/7/1108748447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007076,
-    "geom:area_square_m":78003899.185293,
+    "geom:area_square_m":78003894.553864,
     "geom:bbox":"90.509204,26.868324,90.633295,26.979277",
     "geom:latitude":26.929214,
     "geom:longitude":90.562302,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328494,
-    "wof:geomhash":"cb7414a55e55aa756df2723599e35c4d",
+    "wof:geomhash":"17bb50cb379974d1902c221339565d2c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748447,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Sherzhong",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/844/9/1108748449.geojson
+++ b/data/110/874/844/9/1108748449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028096,
-    "geom:area_square_m":308926876.384643,
+    "geom:area_square_m":308927082.475321,
     "geom:bbox":"90.856683,27.045252,91.021268,27.372603",
     "geom:latitude":27.222812,
     "geom:longitude":90.923023,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SG.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328494,
-    "wof:geomhash":"3c1ba5b357c3cd8afb94d8a9b32e51d0",
+    "wof:geomhash":"19147de6cf308031b30124617267ca00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748449,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shingkhar",
     "wof:parent_id":85669559,
     "wof:placetype":"county",

--- a/data/110/874/845/1/1108748451.geojson
+++ b/data/110/874/845/1/1108748451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001905,
-    "geom:area_square_m":21017347.651871,
+    "geom:area_square_m":21017348.850869,
     "geom:bbox":"90.256816,26.849888,90.317251,26.90613",
     "geom:latitude":26.873291,
     "geom:longitude":90.287075,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328494,
-    "wof:geomhash":"17df74bf903770c3b7e05a62fe8a6b96",
+    "wof:geomhash":"710e1d8cb4c29bb78eb62adee231e7cd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748451,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886221,
     "wof:name":"Shompangkha",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/845/3/1108748453.geojson
+++ b/data/110/874/845/3/1108748453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008509,
-    "geom:area_square_m":93498424.938908,
+    "geom:area_square_m":93498406.168257,
     "geom:bbox":"91.6235,27.234325,91.722258,27.363743",
     "geom:latitude":27.300022,
     "geom:longitude":91.672571,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TA.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328494,
-    "wof:geomhash":"d2a162ba913cb914ad119fcf826ee214",
+    "wof:geomhash":"6688173ef8d988bec4e6c4638608d5cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748453,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Shongphu",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/110/874/845/5/1108748455.geojson
+++ b/data/110/874/845/5/1108748455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008423,
-    "geom:area_square_m":92727573.445014,
+    "geom:area_square_m":92727410.439684,
     "geom:bbox":"91.339912,27.007876,91.462514,27.170402",
     "geom:latitude":27.094062,
     "geom:longitude":91.393502,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PM.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328495,
-    "wof:geomhash":"c09e02aa346744869b01059d110c909f",
+    "wof:geomhash":"be6c510af78fdbc105da61ac348918a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748455,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Shumer",
     "wof:parent_id":85669575,
     "wof:placetype":"county",

--- a/data/110/874/845/9/1108748459.geojson
+++ b/data/110/874/845/9/1108748459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014594,
-    "geom:area_square_m":160619001.620128,
+    "geom:area_square_m":160619043.741622,
     "geom:bbox":"91.003653,27.037777,91.187747,27.204109",
     "geom:latitude":27.122262,
     "geom:longitude":91.074656,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.MO.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328495,
-    "wof:geomhash":"aa406adae3c8fbf14732083ac55925d6",
+    "wof:geomhash":"a5514e2a36f23d98adcc18fa4cb956e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748459,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Silambi",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/110/874/846/1/1108748461.geojson
+++ b/data/110/874/846/1/1108748461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002287,
-    "geom:area_square_m":25193524.601004,
+    "geom:area_square_m":25193577.446162,
     "geom:bbox":"88.870207,26.951847,88.913829,27.055783",
     "geom:latitude":26.99939,
     "geom:longitude":88.886968,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328495,
-    "wof:geomhash":"3d3f1a6b5442f6b05e9491123262389e",
+    "wof:geomhash":"f1645d1e69328bb79adaf31b207e403f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748461,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Sipsu",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/846/3/1108748463.geojson
+++ b/data/110/874/846/3/1108748463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016328,
-    "geom:area_square_m":178623205.429839,
+    "geom:area_square_m":178623264.94943,
     "geom:bbox":"89.223622,27.717403,89.415109,27.857423",
     "geom:latitude":27.782369,
     "geom:longitude":89.318311,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"BT.TM.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328495,
-    "wof:geomhash":"10aec22b0ea302a45f5b3336f07a4005",
+    "wof:geomhash":"c6f137b03f79266e5bfd6f465bc1f016",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108748463,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Soe",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/110/874/846/5/1108748465.geojson
+++ b/data/110/874/846/5/1108748465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046294,
-    "geom:area_square_m":509059512.230134,
+    "geom:area_square_m":509059527.51732,
     "geom:bbox":"88.907513,27.072105,89.233163,27.337657",
     "geom:latitude":27.216608,
     "geom:longitude":89.074829,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.HA.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328496,
-    "wof:geomhash":"5b2a6fe6b7bf9123fa7f179bf0bb5188",
+    "wof:geomhash":"2f3d2d8490d05ca9f66ce97306ed30b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748465,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Sombey",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/110/874/846/7/1108748467.geojson
+++ b/data/110/874/846/7/1108748467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009851,
-    "geom:area_square_m":108641425.176413,
+    "geom:area_square_m":108641345.331729,
     "geom:bbox":"89.191208,26.824956,89.373515,26.936854",
     "geom:latitude":26.887129,
     "geom:longitude":89.280653,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.SM.TD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328496,
-    "wof:geomhash":"9a07493b57d0d42aa8db9699654fe7f7",
+    "wof:geomhash":"0a7b78d6f4f51745b573a0315de37092",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748467,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Tading",
     "wof:parent_id":85669523,
     "wof:placetype":"county",

--- a/data/110/874/846/9/1108748469.geojson
+++ b/data/110/874/846/9/1108748469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009829,
-    "geom:area_square_m":108475183.769183,
+    "geom:area_square_m":108475221.828345,
     "geom:bbox":"90.542005,26.768659,90.775688,26.850063",
     "geom:latitude":26.808079,
     "geom:longitude":90.670252,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.GE.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328496,
-    "wof:geomhash":"73b20c4f8f020bb301b2351579ecf52e",
+    "wof:geomhash":"1cff352b89bef5632d72855964022fd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748469,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886223,
     "wof:name":"Taklai",
     "wof:parent_id":85669545,
     "wof:placetype":"county",

--- a/data/110/874/850/1/1108748501.geojson
+++ b/data/110/874/850/1/1108748501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003346,
-    "geom:area_square_m":36854556.352826,
+    "geom:area_square_m":36854581.901428,
     "geom:bbox":"90.00868,26.998141,90.075633,27.073569",
     "geom:latitude":27.033778,
     "geom:longitude":90.046393,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328500,
-    "wof:geomhash":"6528268f2cb46acf747b8e73941db849",
+    "wof:geomhash":"b31e47616fa1a6158b3ff138c08fcc93",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748501,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886224,
     "wof:name":"Tsangkha",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/850/3/1108748503.geojson
+++ b/data/110/874/850/3/1108748503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00881,
-    "geom:area_square_m":97175868.479414,
+    "geom:area_square_m":97175941.142605,
     "geom:bbox":"89.874577,26.798719,90.00318,26.961891",
     "geom:latitude":26.869584,
     "geom:longitude":89.941752,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.TG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328500,
-    "wof:geomhash":"1c6f2588b7bbf63154b20dc431fb781d",
+    "wof:geomhash":"55f5111b234f96ff790ab6efad07937b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748503,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Tsendagang",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/110/874/850/5/1108748505.geojson
+++ b/data/110/874/850/5/1108748505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011385,
-    "geom:area_square_m":124909470.865301,
+    "geom:area_square_m":124909466.051133,
     "geom:bbox":"91.169652,27.401178,91.295081,27.534375",
     "geom:latitude":27.471192,
     "geom:longitude":91.226834,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.LH.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328501,
-    "wof:geomhash":"73c7730fcaa8fe8997d6a136555cada2",
+    "wof:geomhash":"1457858e5c64a71c11d6a2c05d93faea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748505,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886225,
     "wof:name":"Tsenkhar",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/110/874/850/7/1108748507.geojson
+++ b/data/110/874/850/7/1108748507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052212,
-    "geom:area_square_m":572069481.317026,
+    "geom:area_square_m":572069475.8168,
     "geom:bbox":"89.12804,27.432115,89.42303,27.773894",
     "geom:latitude":27.614896,
     "geom:longitude":89.288587,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.PR.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328501,
-    "wof:geomhash":"a82bab59c3789a9b9f07a3e54e81cb73",
+    "wof:geomhash":"bb8f1039876c3bb9a72c18fb31ace5ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748507,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886226,
     "wof:name":"Tsento",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/110/874/850/9/1108748509.geojson
+++ b/data/110/874/850/9/1108748509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053945,
-    "geom:area_square_m":593509500.963656,
+    "geom:area_square_m":593509505.784349,
     "geom:bbox":"89.634339,27.035841,89.948093,27.280829",
     "geom:latitude":27.156326,
     "geom:longitude":89.785068,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"BT.DA.TZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1479328502,
-    "wof:geomhash":"8a8619f57ca12ef77f1ea0fcda3b36e9",
+    "wof:geomhash":"22586c830bc416917d7c83db0ff0a579",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108748509,
-    "wof:lastmodified":1627521906,
+    "wof:lastmodified":1695886226,
     "wof:name":"Tseza",
     "wof:parent_id":85669505,
     "wof:placetype":"county",

--- a/data/421/166/613/421166613.geojson
+++ b/data/421/166/613/421166613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001804,
-    "geom:area_square_m":19792628.974314,
+    "geom:area_square_m":19792647.29443,
     "geom:bbox":"89.858065,27.460552,89.918668,27.521542",
     "geom:latitude":27.491544,
     "geom:longitude":89.892642,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.WP.TD",
         "qs_pg:id":1248813
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008696,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28c7e58d6c840f4c1b47205068811902",
+    "wof:geomhash":"98c5b33a55558a2e6dbcdb9b362f49e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421166613,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Thedtsho",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/169/587/421169587.geojson
+++ b/data/421/169/587/421169587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003749,
-    "geom:area_square_m":41152876.499038,
+    "geom:area_square_m":41152751.59379,
     "geom:bbox":"89.24128,27.367166,89.33226,27.4433",
     "geom:latitude":27.398544,
     "geom:longitude":89.288608,
@@ -100,12 +100,13 @@
         "qs_pg:id":213436,
         "wd:id":"Q6378025"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008816,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e4667911f0123410b4d76e6ee7a03c8",
+    "wof:geomhash":"b18dc90e0149cc1045ec782b50f20f82",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":421169587,
-    "wof:lastmodified":1690863603,
+    "wof:lastmodified":1695886212,
     "wof:name":"Katsho",
     "wof:parent_id":85669509,
     "wof:placetype":"county",

--- a/data/421/170/333/421170333.geojson
+++ b/data/421/170/333/421170333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012553,
-    "geom:area_square_m":137994570.575403,
+    "geom:area_square_m":137994570.575338,
     "geom:bbox":"89.3311700822,27.1898764257,89.5210570214,27.3194223472",
     "geom:latitude":27.248444,
     "geom:longitude":89.411623,
@@ -221,12 +221,13 @@
         "hasc:id":"BT.PR.NJ",
         "qs_pg:id":1306506
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008849,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eb768514445fe07e1d9c6ab66e06ce8a",
+    "wof:geomhash":"ef6b2fb17583f69780c357531b91db45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -236,7 +237,7 @@
         }
     ],
     "wof:id":421170333,
-    "wof:lastmodified":1582318821,
+    "wof:lastmodified":1695886595,
     "wof:name":"Naja",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/421/171/015/421171015.geojson
+++ b/data/421/171/015/421171015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050988,
-    "geom:area_square_m":558712942.133499,
+    "geom:area_square_m":558712578.165829,
     "geom:bbox":"90.316471,27.466743,90.593192,27.784298",
     "geom:latitude":27.604412,
     "geom:longitude":90.467799,
@@ -90,12 +90,13 @@
         "hasc:id":"BT.TO.NB",
         "qs_pg:id":1205646
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008878,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"649b6da37e694350c41364d251ecd936",
+    "wof:geomhash":"439f5c488881b4099a8b3ccbccc70896",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421171015,
-    "wof:lastmodified":1627521901,
+    "wof:lastmodified":1695886217,
     "wof:name":"Nubi",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/421/171/403/421171403.geojson
+++ b/data/421/171/403/421171403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009149,
-    "geom:area_square_m":100374744.858802,
+    "geom:area_square_m":100374700.314514,
     "geom:bbox":"90.055974,27.412188,90.203679,27.524929",
     "geom:latitude":27.465349,
     "geom:longitude":90.135575,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.WP.GT",
         "qs_pg:id":1248814
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008892,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd7ab869e9cf75cc412e6579523b4529",
+    "wof:geomhash":"a847d70542b5c71ffd40ae29b73205da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421171403,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886209,
     "wof:name":"Gangte",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/172/353/421172353.geojson
+++ b/data/421/172/353/421172353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004497,
-    "geom:area_square_m":49352791.951171,
+    "geom:area_square_m":49352791.951242,
     "geom:bbox":"89.3051262436,27.3906639574,89.4091060649,27.48386453",
     "geom:latitude":27.438438,
     "geom:longitude":89.357839,
@@ -99,12 +99,13 @@
         "hasc:id":"BT.PR.LA",
         "qs_pg:id":1306507
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459008932,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0afea1937b7a04ee4b2584bb40ccb04",
+    "wof:geomhash":"1fbb64f829f061018aef09e7effe47ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":421172353,
-    "wof:lastmodified":1582318821,
+    "wof:lastmodified":1695886595,
     "wof:name":"Lamgong",
     "wof:parent_id":85669513,
     "wof:placetype":"county",

--- a/data/421/177/849/421177849.geojson
+++ b/data/421/177/849/421177849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048944,
-    "geom:area_square_m":535697096.361649,
+    "geom:area_square_m":535697077.276026,
     "geom:bbox":"90.857563,27.597893,91.245801,27.84746",
     "geom:latitude":27.728362,
     "geom:longitude":91.068153,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.LH.GZ",
         "qs_pg:id":1354420
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009162,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc08db0fbe5625095997a5b75a4e2844",
+    "wof:geomhash":"c55e8161c8e05117c9c720aca433f389",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421177849,
-    "wof:lastmodified":1627521896,
+    "wof:lastmodified":1695886209,
     "wof:name":"Gangzur",
     "wof:parent_id":85669549,
     "wof:placetype":"county",

--- a/data/421/183/063/421183063.geojson
+++ b/data/421/183/063/421183063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015754,
-    "geom:area_square_m":172615658.651737,
+    "geom:area_square_m":172615705.696841,
     "geom:bbox":"90.094966,27.507497,90.266352,27.68956",
     "geom:latitude":27.60947,
     "geom:longitude":90.184019,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.WP.DC",
         "qs_pg:id":959719
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009357,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"effc4b94537bc222413629fe7f4bb686",
+    "wof:geomhash":"53ee510b69d5703b79496e6b514721fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421183063,
-    "wof:lastmodified":1627521895,
+    "wof:lastmodified":1695886208,
     "wof:name":"Dangchhu",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/183/963/421183963.geojson
+++ b/data/421/183/963/421183963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008266,
-    "geom:area_square_m":90824973.132974,
+    "geom:area_square_m":90824929.492267,
     "geom:bbox":"91.527799,27.245187,91.647052,27.352817",
     "geom:latitude":27.303504,
     "geom:longitude":91.59273,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.TA.SM",
         "qs_pg:id":986968
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a59041726d1d76140e9f6c612f18d42f",
+    "wof:geomhash":"ff91cd24e9d24b36c0cc463b39385f00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421183963,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886218,
     "wof:name":"Samkhar",
     "wof:parent_id":85669583,
     "wof:placetype":"county",

--- a/data/421/183/965/421183965.geojson
+++ b/data/421/183/965/421183965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033887,
-    "geom:area_square_m":371965409.809698,
+    "geom:area_square_m":371965734.176723,
     "geom:bbox":"90.263257,27.285107,90.52509,27.524709",
     "geom:latitude":27.414317,
     "geom:longitude":90.389586,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.TO.TJ",
         "qs_pg:id":986969
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7194644586250c48460649dd40d09cae",
+    "wof:geomhash":"04211a923a394b885b5d9e4fa5f81809",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421183965,
-    "wof:lastmodified":1627521904,
+    "wof:lastmodified":1695886222,
     "wof:name":"Tangsibji",
     "wof:parent_id":85669563,
     "wof:placetype":"county",

--- a/data/421/183/967/421183967.geojson
+++ b/data/421/183/967/421183967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101221,
-    "geom:area_square_m":1107329373.912746,
+    "geom:area_square_m":1107329379.204097,
     "geom:bbox":"90.19523,27.476364,90.533665,28.050484",
     "geom:latitude":27.782563,
     "geom:longitude":90.355339,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.WP.SP",
         "qs_pg:id":986970
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a61e8bb1e0cf6806cc4d48b3c4394865",
+    "wof:geomhash":"2d3c14f5f089956627a4a3071ee98f0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421183967,
-    "wof:lastmodified":1627521903,
+    "wof:lastmodified":1695886220,
     "wof:name":"Sephu",
     "wof:parent_id":85669565,
     "wof:placetype":"county",

--- a/data/421/184/419/421184419.geojson
+++ b/data/421/184/419/421184419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041937,
-    "geom:area_square_m":460953441.805562,
+    "geom:area_square_m":460953327.181722,
     "geom:bbox":"90.957456,27.111297,91.238638,27.398673",
     "geom:latitude":27.262994,
     "geom:longitude":91.09787,
@@ -97,12 +97,13 @@
         "qs_pg:id":996337,
         "wd:id":"Q16693964"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459009410,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"724b578685e92ecdf06552b7b34f0db4",
+    "wof:geomhash":"e2fcf43376cc6e0f60d484ba65274263",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421184419,
-    "wof:lastmodified":1627521902,
+    "wof:lastmodified":1695886219,
     "wof:name":"Saleng",
     "wof:parent_id":85669571,
     "wof:placetype":"county",

--- a/data/421/204/105/421204105.geojson
+++ b/data/421/204/105/421204105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139707,
-    "geom:area_square_m":1527899830.594995,
+    "geom:area_square_m":1527900160.763131,
     "geom:bbox":"90.479833,27.491521,90.84576,28.080781",
     "geom:latitude":27.814998,
     "geom:longitude":90.669805,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.BU.CK",
         "qs_pg:id":238072
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459010174,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f605c3d3ce14e3fd807c388fa6ba61c9",
+    "wof:geomhash":"84ae759724326a8c8350bc631ddb2636",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421204105,
-    "wof:lastmodified":1627521894,
+    "wof:lastmodified":1695886207,
     "wof:name":"Chhoekhor",
     "wof:parent_id":85669537,
     "wof:placetype":"county",

--- a/data/421/204/395/421204395.geojson
+++ b/data/421/204/395/421204395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038035,
-    "geom:area_square_m":416256478.577707,
+    "geom:area_square_m":416256397.674354,
     "geom:bbox":"89.800258,27.609995,90.067271,27.862356",
     "geom:latitude":27.740735,
     "geom:longitude":89.933042,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.PN.TO",
         "qs_pg:id":1306510
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459010185,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bc9244e209fa6f76f62bcf92bd731987",
+    "wof:geomhash":"92424a404180f531d541c1f7d89b4b1a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421204395,
-    "wof:lastmodified":1627521905,
+    "wof:lastmodified":1695886223,
     "wof:name":"Toewang",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/421/204/397/421204397.geojson
+++ b/data/421/204/397/421204397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00837,
-    "geom:area_square_m":91660045.163333,
+    "geom:area_square_m":91660210.187963,
     "geom:bbox":"89.772863,27.588283,89.897564,27.741613",
     "geom:latitude":27.665916,
     "geom:longitude":89.836626,
@@ -112,12 +112,13 @@
         "qs_pg:id":1306511,
         "wd:id":"Q969481"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459010185,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e581efe39691adb01975c85ce0f19faf",
+    "wof:geomhash":"116358be9b5e108c2e4319717e6de25f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421204397,
-    "wof:lastmodified":1690863603,
+    "wof:lastmodified":1695886595,
     "wof:name":"Chhubu",
     "wof:parent_id":85669531,
     "wof:placetype":"county",

--- a/data/421/205/147/421205147.geojson
+++ b/data/421/205/147/421205147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027192,
-    "geom:area_square_m":298063405.090338,
+    "geom:area_square_m":298063323.850474,
     "geom:bbox":"89.50372,27.471566,89.710512,27.673479",
     "geom:latitude":27.564888,
     "geom:longitude":89.608291,
@@ -89,12 +89,13 @@
         "hasc:id":"BT.TM.KW",
         "qs_pg:id":179776
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BT",
     "wof:created":1459010214,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f643492fb42eb9a6c9b82b035c3bf097",
+    "wof:geomhash":"339d8b33b7dab5b0515f2115db56138a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421205147,
-    "wof:lastmodified":1627521898,
+    "wof:lastmodified":1695886212,
     "wof:name":"Kawang",
     "wof:parent_id":85669527,
     "wof:placetype":"county",

--- a/data/856/321/71/85632171.geojson
+++ b/data/856/321/71/85632171.geojson
@@ -1230,6 +1230,7 @@
         "hasc:id":"BT",
         "icao:code":"A5",
         "ioc:id":"BHU",
+        "iso:code":"BT",
         "itu:id":"BTN",
         "loc:id":"n79149023",
         "m49:code":"064",
@@ -1243,6 +1244,7 @@
         "wd:id":"Q917",
         "wk:page":"Bhutan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:country_alpha3":"BTN",
     "wof:geom_alt":[
@@ -1266,7 +1268,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1694639596,
+    "wof:lastmodified":1695881257,
     "wof:name":"Bhutan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/695/01/85669501.geojson
+++ b/data/856/695/01/85669501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.171016,
-    "geom:area_square_m":1884367942.403504,
+    "geom:area_square_m":1884368038.608677,
     "geom:bbox":"89.265706,26.717506,89.824569,27.315521",
     "geom:latitude":26.987266,
     "geom:longitude":89.544814,
@@ -300,17 +300,19 @@
         "gn:id":1337279,
         "gp:id":2344873,
         "hasc:id":"BT.CK",
+        "iso:code":"BT-12",
         "iso:id":"BT-12",
         "qs_pg:id":1168619,
         "unlc:id":"BT-12",
         "wd:id":"Q652754",
         "wk:page":"Chukha District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1734baeed8602c2a8c41596c215c5061",
+    "wof:geomhash":"b58923e7647ef53553339cd73aa5fbdb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863598,
+    "wof:lastmodified":1695884338,
     "wof:name":"Chhukha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/05/85669505.geojson
+++ b/data/856/695/05/85669505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15692,
-    "geom:area_square_m":1728887113.20742,
+    "geom:area_square_m":1728887063.181213,
     "geom:bbox":"89.634339,26.702016,90.076062,27.280829",
     "geom:latitude":26.997944,
     "geom:longitude":89.871961,
@@ -263,16 +263,18 @@
         "gn:id":1337280,
         "gp:id":2344875,
         "hasc:id":"BT.DA",
+        "iso:code":"BT-22",
         "iso:id":"BT-22",
         "qs_pg:id":191313,
         "wd:id":"Q735146",
         "wk:page":"Dagana District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"43210567a67267679ff752572d3342a9",
+    "wof:geomhash":"f9b60263ed55f10fea430dd8f7aa0870",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863595,
+    "wof:lastmodified":1695884805,
     "wof:name":"Daga",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/09/85669509.geojson
+++ b/data/856/695/09/85669509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164947,
-    "geom:area_square_m":1812444220.106617,
+    "geom:area_square_m":1812443974.607701,
     "geom:bbox":"88.907513,27.027831,89.385598,27.613511",
     "geom:latitude":27.298659,
     "geom:longitude":89.153779,
@@ -289,17 +289,19 @@
         "gn:id":1337283,
         "gp:id":2344877,
         "hasc:id":"BT.HA",
+        "iso:code":"BT-13",
         "iso:id":"BT-13",
         "qs_pg:id":894848,
         "unlc:id":"BT-13",
         "wd:id":"Q754448",
         "wk:page":"Haa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e704c305e4616ac0555615e39d6c552",
+    "wof:geomhash":"ccea4634944a7cde491afc9b62663e88",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -314,7 +316,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863597,
+    "wof:lastmodified":1695884805,
     "wof:name":"Ha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/13/85669513.geojson
+++ b/data/856/695/13/85669513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116919,
-    "geom:area_square_m":1282447170.084065,
+    "geom:area_square_m":1282447068.975638,
     "geom:bbox":"89.12804,27.189876,89.550493,27.773894",
     "geom:latitude":27.49326,
     "geom:longitude":89.367828,
@@ -308,17 +308,19 @@
         "gn:id":1337286,
         "gp:id":2344880,
         "hasc:id":"BT.PR",
+        "iso:code":"BT-11",
         "iso:id":"BT-11",
         "qs_pg:id":427257,
         "unlc:id":"BT-11",
         "wd:id":"Q652784",
         "wk:page":"Paro District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01648c471caa2567923edd1377be0365",
+    "wof:geomhash":"ff48796eb3d05d726c9ec5f47ad96e4a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863600,
+    "wof:lastmodified":1695884806,
     "wof:name":"Paro",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/21/85669521.geojson
+++ b/data/856/695/21/85669521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.287406,
-    "geom:area_square_m":3137873281.523294,
+    "geom:area_square_m":3137873320.176947,
     "geom:bbox":"89.451154,27.723609,90.455649,28.246987",
     "geom:latitude":27.998813,
     "geom:longitude":89.894579,
@@ -296,17 +296,19 @@
         "gn:id":7303651,
         "gp:id":55967862,
         "hasc:id":"BT.GA",
+        "iso:code":"BT-GA",
         "iso:id":"BT-GA",
         "qs_pg:id":74832,
         "unlc:id":"BT-GA",
         "wd:id":"Q578294",
         "wk:page":"Gasa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4738a5b99c120db65289e49e9f4b27fb",
+    "wof:geomhash":"977985697c0c27dcf60a391433c61e67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863596,
+    "wof:lastmodified":1695884805,
     "wof:name":"Gasa",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/23/85669523.geojson
+++ b/data/856/695/23/85669523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.118401,
-    "geom:area_square_m":1304180497.707621,
+    "geom:area_square_m":1304180502.979575,
     "geom:bbox":"88.746474,26.811258,89.373515,27.275661",
     "geom:latitude":27.025322,
     "geom:longitude":89.061411,
@@ -295,16 +295,18 @@
         "gn:id":1337289,
         "gp:id":2344883,
         "hasc:id":"BT.SM",
+        "iso:code":"BT-14",
         "iso:id":"BT-14",
         "qs_pg:id":318320,
         "wd:id":"Q728917",
         "wk:page":"Samtse District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1b5822458c87c92433b8fe8e6f37fd82",
+    "wof:geomhash":"c4ed910b4821e083b6834fe0c908ed69",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863599,
+    "wof:lastmodified":1695884806,
     "wof:name":"Samchi",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/27/85669527.geojson
+++ b/data/856/695/27/85669527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164058,
-    "geom:area_square_m":1797754924.107275,
+    "geom:area_square_m":1797755088.105605,
     "geom:bbox":"89.223622,27.145278,89.762991,27.996897",
     "geom:latitude":27.59943,
     "geom:longitude":89.540037,
@@ -296,17 +296,19 @@
         "gn:id":1337293,
         "gp:id":2344887,
         "hasc:id":"BT.TM",
+        "iso:code":"BT-15",
         "iso:id":"BT-15",
         "qs_pg:id":219517,
         "unlc:id":"BT-15",
         "wd:id":"Q254889",
         "wk:page":"Thimphu District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68612cbaeb7689ef8c2a99f37ace8743",
+    "wof:geomhash":"dc4d7c16fcd1e80c4a0efa9bb15d43d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863595,
+    "wof:lastmodified":1695884805,
     "wof:name":"Thimphu",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/31/85669531.geojson
+++ b/data/856/695/31/85669531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101657,
-    "geom:area_square_m":1113316564.950751,
+    "geom:area_square_m":1113316515.899325,
     "geom:bbox":"89.632702,27.467102,90.067271,27.862356",
     "geom:latitude":27.66352,
     "geom:longitude":89.85011,
@@ -296,17 +296,19 @@
         "gn:id":1337288,
         "gp:id":2344882,
         "hasc:id":"BT.PN",
+        "iso:code":"BT-23",
         "iso:id":"BT-23",
         "qs_pg:id":1285054,
         "unlc:id":"BT-23",
         "wd:id":"Q587062",
         "wk:page":"Punakha District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ccc3dc1c7ce8186109a63851b78bc43f",
+    "wof:geomhash":"735b3090356650c6ae8688247e3d3002",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863597,
+    "wof:lastmodified":1695884805,
     "wof:name":"Punakha",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/37/85669537.geojson
+++ b/data/856/695/37/85669537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248357,
-    "geom:area_square_m":2719039086.32155,
+    "geom:area_square_m":2719039173.249413,
     "geom:bbox":"90.479833,27.335471,91.012641,28.080781",
     "geom:latitude":27.698906,
     "geom:longitude":90.743241,
@@ -305,17 +305,19 @@
         "gn:id":1337278,
         "gp:id":2344872,
         "hasc:id":"BT.BU",
+        "iso:code":"BT-33",
         "iso:id":"BT-33",
         "qs_pg:id":222811,
         "unlc:id":"BT-33",
         "wd:id":"Q463242",
         "wk:page":"Bumthang District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13a351bfabc2a41c403d5120166e59f5",
+    "wof:geomhash":"a7dc3aa582cde24029e8e792b5ffd9bb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863597,
+    "wof:lastmodified":1695884805,
     "wof:name":"Bumthang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/41/85669541.geojson
+++ b/data/856/695/41/85669541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058017,
-    "geom:area_square_m":639061089.202097,
+    "geom:area_square_m":639061215.95911,
     "geom:bbox":"90.006377,26.818505,90.345475,27.190965",
     "geom:latitude":27.024744,
     "geom:longitude":90.146752,
@@ -259,16 +259,18 @@
         "gn:id":1337281,
         "gp:id":2344874,
         "hasc:id":"BT.CR",
+        "iso:code":"BT-21",
         "iso:id":"BT-21",
         "qs_pg:id":1168618,
         "wd:id":"Q728922",
         "wk:page":"Tsirang District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89ef1492c2a9127b248197629a0df08d",
+    "wof:geomhash":"e1ab7859dd7dc6aa40af1cf09706f8c0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863599,
+    "wof:lastmodified":1695884806,
     "wof:name":"Chirang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/45/85669545.geojson
+++ b/data/856/695/45/85669545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150297,
-    "geom:area_square_m":1656418778.38761,
+    "geom:area_square_m":1656418603.909503,
     "geom:bbox":"90.011657,26.729808,90.775688,27.221355",
     "geom:latitude":26.963825,
     "geom:longitude":90.41914,
@@ -248,16 +248,18 @@
         "gn:id":1337282,
         "gp:id":2344876,
         "hasc:id":"BT.GE",
+        "iso:code":"BT-31",
         "iso:id":"BT-31",
         "qs_pg:id":264449,
         "wd:id":"Q728947",
         "wk:page":"Sarpang District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cbe757e9caa15f5e34a02c0ac2781449",
+    "wof:geomhash":"8dbd7d79a02ec0e9f76705a49888880b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -272,7 +274,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863596,
+    "wof:lastmodified":1695884805,
     "wof:name":"Geylegphug",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/49/85669549.geojson
+++ b/data/856/695/49/85669549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263826,
-    "geom:area_square_m":2886487226.206233,
+    "geom:area_square_m":2886487357.379466,
     "geom:bbox":"90.772701,27.390567,91.474827,28.071089",
     "geom:latitude":27.770961,
     "geom:longitude":91.131537,
@@ -292,16 +292,18 @@
         "gn:id":1337284,
         "gp:id":2344878,
         "hasc:id":"BT.LH",
+        "iso:code":"BT-44",
         "iso:id":"BT-44",
         "qs_pg:id":1083805,
         "wd:id":"Q598793",
         "wk:page":"Lhuntse District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20b455056e47c4cf9ab137285d305f30",
+    "wof:geomhash":"746d6086e85f9edd25377d518ff3f388",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863600,
+    "wof:lastmodified":1695884806,
     "wof:name":"Lhuntshi",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/55/85669555.geojson
+++ b/data/856/695/55/85669555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132003,
-    "geom:area_square_m":1445608377.804182,
+    "geom:area_square_m":1445608563.305879,
     "geom:bbox":"91.336141,27.37515,91.767733,27.980017",
     "geom:latitude":27.667103,
     "geom:longitude":91.499984,
@@ -182,15 +182,17 @@
         "gn:id":7303653,
         "gp:id":55967863,
         "hasc:id":"BT.TY",
+        "iso:code":"BT-TY",
         "iso:id":"BT-TY",
         "qs_pg:id":74603,
         "wd:id":"Q2566021"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"392ec639cbbe11a4da8f20e988565e38",
+    "wof:geomhash":"ce8ef57935e86216970f0c5144dbfe36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +207,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863598,
+    "wof:lastmodified":1695884806,
     "wof:name":"Tashi Yangtse",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/59/85669559.geojson
+++ b/data/856/695/59/85669559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.219824,
-    "geom:area_square_m":2420691308.31146,
+    "geom:area_square_m":2420691679.163699,
     "geom:bbox":"90.52974,26.775216,91.180865,27.388318",
     "geom:latitude":27.056096,
     "geom:longitude":90.856224,
@@ -288,16 +288,18 @@
         "gn:id":1337291,
         "gp:id":2344885,
         "hasc:id":"BT.SG",
+        "iso:code":"BT-34",
         "iso:id":"BT-34",
         "qs_pg:id":555798,
         "wd:id":"Q197564",
         "wk:page":"Zhemgang District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dfab7e56c22f31cec2a8c6a043624f5",
+    "wof:geomhash":"1d234963222d60ac298874a67d334fa0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863595,
+    "wof:lastmodified":1695884805,
     "wof:name":"Shemgang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/63/85669563.geojson
+++ b/data/856/695/63/85669563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165479,
-    "geom:area_square_m":1816320651.82268,
+    "geom:area_square_m":1816320670.512539,
     "geom:bbox":"90.263257,27.136251,90.749246,27.784298",
     "geom:latitude":27.418591,
     "geom:longitude":90.496025,
@@ -292,16 +292,18 @@
         "gn:id":1337294,
         "gp:id":2344888,
         "hasc:id":"BT.TO",
+        "iso:code":"BT-32",
         "iso:id":"BT-32",
         "qs_pg:id":219518,
         "wd:id":"Q728938",
         "wk:page":"Trongsa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02cfb0ac49fa2e65d55b9692fbde2409",
+    "wof:geomhash":"66b16d5d4c9990095380fe4437cd65e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863598,
+    "wof:lastmodified":1695884806,
     "wof:name":"Tongsa",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/65/85669565.geojson
+++ b/data/856/695/65/85669565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368532,
-    "geom:area_square_m":4040456115.732226,
+    "geom:area_square_m":4040456037.629017,
     "geom:bbox":"89.709221,27.123211,90.533665,28.050484",
     "geom:latitude":27.543244,
     "geom:longitude":90.153204,
@@ -143,15 +143,17 @@
         "gn:id":1337295,
         "gp:id":2344889,
         "hasc:id":"BT.WP",
+        "iso:code":"BT-24",
         "iso:id":"BT-24",
         "qs_pg:id":221718,
         "unlc:id":"BT-24"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bde54c8e2d6198f0ab1bebcecb134683",
+    "wof:geomhash":"9671c5df42d1b5178eab772bc9fbec44",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1636495661,
+    "wof:lastmodified":1695884805,
     "wof:name":"Wangdi Phodrang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/71/85669571.geojson
+++ b/data/856/695/71/85669571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177061,
-    "geom:area_square_m":1946149797.679852,
+    "geom:area_square_m":1946150114.375502,
     "geom:bbox":"90.957456,26.941623,91.4974,27.600487",
     "geom:latitude":27.264525,
     "geom:longitude":91.220502,
@@ -295,16 +295,18 @@
         "gn:id":1337285,
         "gp:id":2344879,
         "hasc:id":"BT.MO",
+        "iso:code":"BT-42",
         "iso:id":"BT-42",
         "qs_pg:id":984067,
         "wd:id":"Q389734",
         "wk:page":"Mongar District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d378ca64b8e04e49b180284a13a4dadb",
+    "wof:geomhash":"ac16f45a4c69fd1dbe3b068df2deb35d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863600,
+    "wof:lastmodified":1695884806,
     "wof:name":"Mongar",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/75/85669575.geojson
+++ b/data/856/695/75/85669575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092735,
-    "geom:area_square_m":1022121456.481254,
+    "geom:area_square_m":1022121052.970061,
     "geom:bbox":"91.002238,26.781255,91.548618,27.178167",
     "geom:latitude":26.954577,
     "geom:longitude":91.30993,
@@ -286,16 +286,18 @@
         "gn:id":1337287,
         "gp:id":2344881,
         "hasc:id":"BT.PM",
+        "iso:code":"BT-43",
         "iso:id":"BT-43",
         "qs_pg:id":1097028,
         "wd:id":"Q167279",
         "wk:page":"Pemagatshel District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3fc0cfa9ce32459a6fca8fe9de1c7d99",
+    "wof:geomhash":"e1d6e4319f42997520e466d0e0c55bc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863596,
+    "wof:lastmodified":1695884338,
     "wof:name":"Pemagatshel",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/79/85669579.geojson
+++ b/data/856/695/79/85669579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169324,
-    "geom:area_square_m":1865983438.430164,
+    "geom:area_square_m":1865983917.704407,
     "geom:bbox":"91.392883,26.793372,92.121346,27.249153",
     "geom:latitude":26.971878,
     "geom:longitude":91.77742,
@@ -312,16 +312,18 @@
         "gn:id":1337290,
         "gp:id":2344884,
         "hasc:id":"BT.SJ",
+        "iso:code":"BT-45",
         "iso:id":"BT-45",
         "qs_pg:id":1097029,
         "wd:id":"Q728929",
         "wk:page":"Samdrup Jongkhar District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"227a3cc777426036cf7b4614e73dbff8",
+    "wof:geomhash":"1feeac86113d4a36d2cd03e4dec6fef2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863599,
+    "wof:lastmodified":1695884806,
     "wof:name":"Samdrup Jongkhar",
     "wof:parent_id":85632171,
     "wof:placetype":"region",

--- a/data/856/695/83/85669583.geojson
+++ b/data/856/695/83/85669583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200701,
-    "geom:area_square_m":2205821236.885365,
+    "geom:area_square_m":2205821066.346418,
     "geom:bbox":"91.375384,27.024999,92.125127,27.486344",
     "geom:latitude":27.273011,
     "geom:longitude":91.741952,
@@ -282,16 +282,18 @@
         "gn:id":1337292,
         "gp:id":2344886,
         "hasc:id":"BT.TA",
+        "iso:code":"BT-41",
         "iso:id":"BT-41",
         "qs_pg:id":1097030,
         "wd:id":"Q652773",
         "wk:page":"Trashigang District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BT",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"218cb395b7e40ce7e4baae90209fef1f",
+    "wof:geomhash":"44d124352210284207cdcac7423b91eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "dzo"
     ],
-    "wof:lastmodified":1690863599,
+    "wof:lastmodified":1695884339,
     "wof:name":"Tashigang",
     "wof:parent_id":85632171,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.